### PR TITLE
feat(recipe): add video_cut_studio_ui recipe

### DIFF
--- a/community-recipes/recipes/video_cut_studio_ui/assets/app.js
+++ b/community-recipes/recipes/video_cut_studio_ui/assets/app.js
@@ -1,0 +1,1190 @@
+/**
+ * Video Clip Annotator - Main Application
+ */
+
+const API_BASE = 'http://127.0.0.1:8093/api';
+
+// Global state
+const state = {
+  config: null,
+  mediaFiles: [],
+  currentMedia: null,
+  markers: {},        // { filename: [{ id, start, end }] }
+  timeline: {
+    order: []         // Media file order for export
+  },
+  ttsClips: [],       // [{ id, text, emotion, audioFile, duration }]
+  pendingMarker: { start: null, end: null }
+};
+
+// DOM Elements
+const elements = {};
+
+// Initialize
+document.addEventListener('DOMContentLoaded', async () => {
+  cacheElements();
+  setupEventListeners();
+  await loadConfig();
+  await loadMediaFiles();
+  await loadSavedData();
+  updateUI();
+  // Preload durations in background
+  preloadMediaDurations();
+});
+
+function cacheElements() {
+  elements.mediaList = document.getElementById('media-list');
+  elements.mediaCount = document.getElementById('media-count');
+  elements.videoPlayer = document.getElementById('video-player');
+  elements.playerOverlay = document.getElementById('player-overlay');
+  elements.waveformCanvas = document.getElementById('waveform-canvas');
+  elements.playhead = document.getElementById('playhead');
+  elements.markersOverlay = document.getElementById('markers-overlay');
+  elements.markerPreview = document.getElementById('marker-preview');
+  elements.btnMarkStart = document.getElementById('btn-mark-start');
+  elements.btnMarkEnd = document.getElementById('btn-mark-end');
+  elements.btnAddMarker = document.getElementById('btn-add-marker');
+  elements.clipMarkers = document.getElementById('clip-markers');
+  elements.markerCount = document.getElementById('marker-count');
+  elements.ttsText = document.getElementById('tts-text');
+  elements.ttsEmotion = document.getElementById('tts-emotion');
+  elements.emotionCombo = document.getElementById('emotion-combo');
+  elements.emotionDropdown = document.getElementById('emotion-dropdown');
+  elements.ttsList = document.getElementById('tts-list');
+  elements.btnGenerateTts = document.getElementById('btn-generate-tts');
+  elements.btnSave = document.getElementById('btn-save');
+  elements.btnExport = document.getElementById('btn-export');
+  elements.statusMessage = document.getElementById('status-message');
+  elements.statusDuration = document.getElementById('status-duration');
+  elements.modalExport = document.getElementById('modal-export');
+  elements.exportProgress = document.getElementById('export-progress');
+  elements.exportStatus = document.getElementById('export-status');
+}
+
+function setupEventListeners() {
+  // Video player events
+  elements.videoPlayer.addEventListener('timeupdate', onTimeUpdate);
+  elements.videoPlayer.addEventListener('loadedmetadata', onMediaLoaded);
+
+  // Marker controls
+  elements.btnMarkStart.addEventListener('click', () => markTime('start'));
+  elements.btnMarkEnd.addEventListener('click', () => markTime('end'));
+  elements.btnAddMarker.addEventListener('click', addMarkerToList);
+
+  // Keyboard shortcuts
+  document.addEventListener('keydown', onKeyDown);
+
+  // TTS
+  elements.btnGenerateTts.addEventListener('click', generateTTS);
+
+  // Save & Export
+  elements.btnSave.addEventListener('click', saveProject);
+  elements.btnExport.addEventListener('click', exportVideo);
+
+  // Waveform click
+  elements.waveformCanvas.addEventListener('click', onWaveformClick);
+
+  // Emotion combo box
+  initEmotionCombo();
+}
+
+// ============================================================
+// Config & Data Loading
+// ============================================================
+
+async function loadConfig() {
+  try {
+    const resp = await fetch('./config.json');
+    state.config = await resp.json();
+    setStatus(`Loaded project: ${state.config.dir}`);
+  } catch (e) {
+    console.error('Failed to load config:', e);
+    setStatus('Error: Failed to load config.json', true);
+  }
+}
+
+async function loadMediaFiles() {
+  if (!state.config?.dir) return;
+
+  // Use mediaFiles from config.json (already scanned and sorted by workflow)
+  if (state.config.mediaFiles && state.config.mediaFiles.length > 0) {
+    state.mediaFiles = state.config.mediaFiles;
+    state.timeline.order = state.mediaFiles.map(f => f.name);
+    renderMediaList();
+    setStatus(`Loaded ${state.mediaFiles.length} media files`);
+  } else {
+    setStatus('No media files found in config', true);
+  }
+}
+
+async function loadSavedData() {
+  if (!state.config?.dir) return;
+
+  // Load markers.json
+  try {
+    const resp = await fetch(`${API_BASE}/file?path=${encodeURIComponent(state.config.dir + '/markers.json')}`);
+    if (resp.ok) {
+      state.markers = await resp.json();
+    }
+  } catch (e) {
+    console.log('No saved markers found');
+  }
+
+  // Load timeline.json
+  try {
+    const resp = await fetch(`${API_BASE}/file?path=${encodeURIComponent(state.config.dir + '/timeline.json')}`);
+    if (resp.ok) {
+      const data = await resp.json();
+      state.timeline = { ...state.timeline, ...data };
+    }
+  } catch (e) {
+    console.log('No saved timeline found');
+  }
+
+  // Load TTS clips
+  try {
+    const resp = await fetch(`${API_BASE}/file?path=${encodeURIComponent(state.config.dir + '/tts_clips.json')}`);
+    if (resp.ok) {
+      state.ttsClips = await resp.json();
+    }
+  } catch (e) {
+    console.log('No TTS clips found');
+  }
+}
+
+// ============================================================
+// Media List
+// ============================================================
+
+function renderMediaList() {
+  elements.mediaList.innerHTML = '';
+  elements.mediaCount.textContent = state.mediaFiles.length;
+
+  state.mediaFiles.forEach((file, index) => {
+    const li = document.createElement('li');
+    li.className = 'media-item';
+    li.dataset.filename = file.name;
+    li.draggable = true;
+
+    const markerCount = (state.markers[file.name] || []).length;
+    const isVideo = /\.(mp4|webm|mov)$/i.test(file.name);
+    const icon = isVideo ? '🎬' : '🎵';
+
+    li.innerHTML = `
+      <span class="drag-handle">⋮⋮</span>
+      <span class="media-icon">${icon}</span>
+      <div class="media-info">
+        <div class="media-name">${file.name}</div>
+        <div class="media-duration">${formatDuration(file.duration || 0)}</div>
+      </div>
+      ${markerCount > 0 ? `<span class="media-markers">${markerCount} markers</span>` : ''}
+    `;
+
+    li.addEventListener('click', () => selectMedia(file));
+    li.addEventListener('dragstart', onDragStart);
+    li.addEventListener('dragover', onDragOver);
+    li.addEventListener('drop', onDrop);
+    li.addEventListener('dragend', onDragEnd);
+
+    if (state.currentMedia?.name === file.name) {
+      li.classList.add('active');
+    }
+
+    elements.mediaList.appendChild(li);
+  });
+}
+
+function selectMedia(file) {
+  state.currentMedia = file;
+  state.pendingMarker = { start: null, end: null };
+
+  // Update active state
+  document.querySelectorAll('.media-item').forEach(el => {
+    el.classList.toggle('active', el.dataset.filename === file.name);
+  });
+
+  // Load media
+  const mediaPath = `${state.config.dir}/${file.name}`;
+  elements.videoPlayer.src = `${API_BASE}/file?path=${encodeURIComponent(mediaPath)}`;
+  elements.playerOverlay.classList.add('hidden');
+
+  // Load and render waveform
+  loadWaveform(mediaPath);
+
+  // Update marker list
+  renderClipMarkers();
+  updateMarkerPreview();
+}
+
+// ============================================================
+// Waveform
+// ============================================================
+
+async function loadWaveform(mediaPath) {
+  const canvas = elements.waveformCanvas;
+  const ctx = canvas.getContext('2d');
+  const width = canvas.offsetWidth;
+  const height = canvas.offsetHeight;
+
+  // Set canvas size for retina
+  canvas.width = width * window.devicePixelRatio;
+  canvas.height = height * window.devicePixelRatio;
+  ctx.scale(window.devicePixelRatio, window.devicePixelRatio);
+
+  // Clear canvas
+  ctx.fillStyle = '#21262d';
+  ctx.fillRect(0, 0, width, height);
+
+  try {
+    const audioContext = new (window.AudioContext || window.webkitAudioContext)();
+    const response = await fetch(`${API_BASE}/file?path=${encodeURIComponent(mediaPath)}`);
+    const arrayBuffer = await response.arrayBuffer();
+    const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
+
+    const data = audioBuffer.getChannelData(0);
+    const step = Math.ceil(data.length / width);
+    const centerY = height / 2;
+
+    // Calculate RMS values for smooth waveform
+    const rmsValues = [];
+    for (let i = 0; i < width; i++) {
+      let sum = 0;
+      for (let j = 0; j < step; j++) {
+        const idx = i * step + j;
+        if (idx < data.length) {
+          sum += data[idx] * data[idx];
+        }
+      }
+      rmsValues.push(Math.sqrt(sum / step));
+    }
+
+    // Normalize and smooth
+    const maxRms = Math.max(...rmsValues, 0.01);
+    const normalized = rmsValues.map(v => (v / maxRms) * (height * 0.45));
+
+    // Draw gradient fill
+    const gradient = ctx.createLinearGradient(0, 0, 0, height);
+    gradient.addColorStop(0, 'rgba(88, 166, 255, 0.8)');
+    gradient.addColorStop(0.5, 'rgba(88, 166, 255, 0.3)');
+    gradient.addColorStop(1, 'rgba(88, 166, 255, 0.8)');
+
+    // Draw smooth waveform using quadratic curves
+    ctx.fillStyle = gradient;
+    ctx.beginPath();
+    ctx.moveTo(0, centerY);
+
+    // Upper half (smooth curve)
+    for (let i = 0; i < width; i++) {
+      const y = centerY - normalized[i];
+      if (i === 0) {
+        ctx.lineTo(i, y);
+      } else {
+        const prevY = centerY - normalized[i - 1];
+        const cpX = i - 0.5;
+        const cpY = (prevY + y) / 2;
+        ctx.quadraticCurveTo(cpX, prevY, i, y);
+      }
+    }
+
+    // Right edge
+    ctx.lineTo(width, centerY);
+
+    // Lower half (mirror, going backwards)
+    for (let i = width - 1; i >= 0; i--) {
+      const y = centerY + normalized[i];
+      if (i === width - 1) {
+        ctx.lineTo(i, y);
+      } else {
+        const nextY = centerY + normalized[i + 1];
+        const cpX = i + 0.5;
+        const cpY = (nextY + y) / 2;
+        ctx.quadraticCurveTo(cpX, nextY, i, y);
+      }
+    }
+
+    ctx.closePath();
+    ctx.fill();
+
+    // Draw center line
+    ctx.strokeStyle = 'rgba(88, 166, 255, 0.5)';
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(0, centerY);
+    ctx.lineTo(width, centerY);
+    ctx.stroke();
+
+    // Render markers on waveform
+    renderWaveformMarkers();
+  } catch (e) {
+    console.error('Failed to load waveform:', e);
+    ctx.fillStyle = '#8b949e';
+    ctx.font = '12px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.fillText('Unable to load waveform', width / 2, height / 2);
+  }
+}
+
+function renderWaveformMarkers() {
+  elements.markersOverlay.innerHTML = '';
+
+  if (!state.currentMedia) return;
+
+  const markers = state.markers[state.currentMedia.name] || [];
+  const duration = elements.videoPlayer.duration || 1;
+  const width = elements.waveformCanvas.offsetWidth;
+
+  markers.forEach(marker => {
+    const left = (marker.start / duration) * width;
+    const right = (marker.end / duration) * width;
+
+    const div = document.createElement('div');
+    div.className = 'marker-region';
+    div.style.left = `${left}px`;
+    div.style.width = `${right - left}px`;
+    div.dataset.markerId = marker.id;
+
+    elements.markersOverlay.appendChild(div);
+  });
+}
+
+// ============================================================
+// Playback & Markers
+// ============================================================
+
+function onTimeUpdate() {
+  const video = elements.videoPlayer;
+  const progress = video.currentTime / (video.duration || 1);
+  const width = elements.waveformCanvas.offsetWidth;
+  elements.playhead.style.left = `${progress * width}px`;
+}
+
+function onMediaLoaded() {
+  // Update duration in mediaFiles
+  if (state.currentMedia) {
+    const duration = elements.videoPlayer.duration;
+    if (duration && !isNaN(duration)) {
+      state.currentMedia.duration = duration;
+      // Update in mediaFiles array
+      const file = state.mediaFiles.find(f => f.name === state.currentMedia.name);
+      if (file) {
+        file.duration = duration;
+      }
+      renderMediaList();
+    }
+  }
+  renderWaveformMarkers();
+  renderClipMarkers();
+}
+
+// Preload all media durations
+async function preloadMediaDurations() {
+  for (const file of state.mediaFiles) {
+    if (file.duration) continue;
+    try {
+      const duration = await getMediaDuration(file.name);
+      file.duration = duration;
+    } catch (e) {
+      console.warn(`Failed to get duration for ${file.name}`);
+    }
+  }
+  renderMediaList();
+}
+
+function getMediaDuration(filename) {
+  return new Promise((resolve, reject) => {
+    const mediaPath = `${state.config.dir}/${filename}`;
+    const video = document.createElement('video');
+    video.preload = 'metadata';
+    video.onloadedmetadata = () => {
+      resolve(video.duration);
+      video.src = '';
+    };
+    video.onerror = reject;
+    video.src = `${API_BASE}/file?path=${encodeURIComponent(mediaPath)}`;
+  });
+}
+
+function onWaveformClick(e) {
+  const rect = elements.waveformCanvas.getBoundingClientRect();
+  const x = e.clientX - rect.left;
+  const progress = x / rect.width;
+  elements.videoPlayer.currentTime = progress * elements.videoPlayer.duration;
+}
+
+function markTime(type) {
+  const time = elements.videoPlayer.currentTime;
+  state.pendingMarker[type] = time;
+  updateMarkerPreview();
+}
+
+function updateMarkerPreview() {
+  const { start, end } = state.pendingMarker;
+  const startStr = start !== null ? formatTime(start) : '--:--';
+  const endStr = end !== null ? formatTime(end) : '--:--';
+  elements.markerPreview.textContent = `${startStr} ~ ${endStr}`;
+
+  const canAdd = start !== null && end !== null && end > start;
+  elements.btnAddMarker.disabled = !canAdd;
+}
+
+function addMarkerToList() {
+  if (!state.currentMedia) return;
+
+  const { start, end } = state.pendingMarker;
+  if (start === null || end === null || end <= start) return;
+
+  const filename = state.currentMedia.name;
+  if (!state.markers[filename]) {
+    state.markers[filename] = [];
+  }
+
+  const marker = {
+    id: `m${Date.now()}`,
+    start: parseFloat(start.toFixed(3)),
+    end: parseFloat(end.toFixed(3))
+  };
+
+  state.markers[filename].push(marker);
+  state.pendingMarker = { start: null, end: null };
+
+  updateMarkerPreview();
+  renderClipMarkers();
+  renderWaveformMarkers();
+  renderMediaList();
+  autoSave();
+}
+
+function removeMarker(markerId, filename) {
+  const targetFile = filename || state.currentMedia?.name;
+  if (!targetFile) return;
+
+  const markers = state.markers[targetFile];
+  if (!markers) return;
+
+  const index = markers.findIndex(m => m.id === markerId);
+  if (index !== -1) {
+    markers.splice(index, 1);
+    renderClipMarkers();
+    renderWaveformMarkers();
+    renderMediaList();
+    autoSave();
+  }
+}
+
+function renderClipMarkers() {
+  // Update marker count badge - count all markers across all files
+  const totalMarkers = Object.values(state.markers).reduce((sum, arr) => sum + arr.length, 0);
+  elements.markerCount.textContent = totalMarkers;
+
+  if (totalMarkers === 0) {
+    elements.clipMarkers.innerHTML = '<li class="empty-state">No markers yet. Use [I] and [O] to mark clips.</li>';
+    return;
+  }
+
+  // Render all markers grouped by file, in timeline order
+  let html = '';
+  for (const filename of state.timeline.order) {
+    const markers = state.markers[filename] || [];
+    if (markers.length === 0) continue;
+
+    const isCurrentFile = state.currentMedia?.name === filename;
+    const shortName = filename.replace(/\.[^.]+$/, '');
+
+    html += `<li class="marker-group ${isCurrentFile ? 'active' : ''}" data-filename="${filename}">
+      <div class="marker-group-header" onclick="selectMediaByName('${filename}')">
+        <span class="marker-group-name">${shortName}</span>
+        <span class="marker-group-count">${markers.length}</span>
+      </div>
+    </li>`;
+
+    html += markers.map((m, index) => {
+      const linkedTts = m.ttsId ? state.ttsClips.find(t => t.id === m.ttsId) : null;
+      const ttsOptions = state.ttsClips.map(t =>
+        `<option value="${t.id}" ${m.ttsId === t.id ? 'selected' : ''}>${escapeHtml(t.text.slice(0, 20))}${t.text.length > 20 ? '...' : ''}</option>`
+      ).join('');
+
+      return `
+        <li class="marker-item ${isCurrentFile ? 'current-file' : ''}" data-marker-id="${m.id}" data-filename="${filename}" data-index="${index}" draggable="true">
+          <span class="drag-handle">⋮⋮</span>
+          <div class="marker-info">
+            <span class="marker-time">${formatTime(m.start)} - ${formatTime(m.end)}</span>
+            <span class="marker-duration">${formatDuration(m.end - m.start)}</span>
+            <div class="marker-tts-link">
+              <select class="tts-select" onchange="linkTtsToMarker('${m.id}', this.value, '${filename}')">
+                <option value="">-- No TTS --</option>
+                ${ttsOptions}
+              </select>
+              ${linkedTts ? `<button class="btn btn-small btn-icon" onclick="playTTS('${linkedTts.id}')" title="Play TTS">🔊</button>` : ''}
+            </div>
+          </div>
+          <div class="marker-actions">
+            <button class="btn btn-small btn-icon" onclick="seekToMarker('${m.id}', '${filename}')" title="Jump to">▶</button>
+            <button class="btn btn-delete" onclick="removeMarker('${m.id}', '${filename}')" title="Delete">×</button>
+          </div>
+        </li>
+      `;
+    }).join('');
+  }
+
+  elements.clipMarkers.innerHTML = html;
+
+  // Setup drag-and-drop for marker reordering
+  setupMarkerDragAndDrop();
+}
+
+function selectMediaByName(filename) {
+  const file = state.mediaFiles.find(f => f.name === filename);
+  if (file) {
+    selectMedia(file);
+  }
+}
+
+function linkTtsToMarker(markerId, ttsId, filename) {
+  const targetFile = filename || state.currentMedia?.name;
+  if (!targetFile) return;
+  const markers = state.markers[targetFile] || [];
+  const marker = markers.find(m => m.id === markerId);
+  if (marker) {
+    marker.ttsId = ttsId || null;
+    autoSave();
+    // Re-render to update UI
+    renderClipMarkers();
+  }
+}
+
+function setupMarkerDragAndDrop() {
+  const items = elements.clipMarkers.querySelectorAll('.marker-item');
+  items.forEach(item => {
+    item.addEventListener('dragstart', onMarkerDragStart);
+    item.addEventListener('dragover', onMarkerDragOver);
+    item.addEventListener('drop', onMarkerDrop);
+    item.addEventListener('dragend', onMarkerDragEnd);
+  });
+}
+
+let draggedMarkerItem = null;
+
+function onMarkerDragStart(e) {
+  draggedMarkerItem = e.target.closest('.marker-item');
+  if (!draggedMarkerItem) return;
+  draggedMarkerItem.classList.add('dragging');
+  e.dataTransfer.effectAllowed = 'move';
+}
+
+function onMarkerDragOver(e) {
+  e.preventDefault();
+  const item = e.target.closest('.marker-item');
+  if (!item || item === draggedMarkerItem) return;
+
+  const rect = item.getBoundingClientRect();
+  const midY = rect.top + rect.height / 2;
+
+  if (e.clientY < midY) {
+    item.parentNode.insertBefore(draggedMarkerItem, item);
+  } else {
+    item.parentNode.insertBefore(draggedMarkerItem, item.nextSibling);
+  }
+}
+
+function onMarkerDrop(e) {
+  e.preventDefault();
+}
+
+function onMarkerDragEnd(e) {
+  if (draggedMarkerItem) {
+    draggedMarkerItem.classList.remove('dragging');
+  }
+
+  // Update markers order in state
+  if (state.currentMedia) {
+    const items = elements.clipMarkers.querySelectorAll('.marker-item');
+    const newOrder = Array.from(items).map(item => item.dataset.markerId);
+    const currentMarkers = state.markers[state.currentMedia.name] || [];
+
+    // Reorder markers based on DOM order
+    const reordered = newOrder.map(id => currentMarkers.find(m => m.id === id)).filter(Boolean);
+    state.markers[state.currentMedia.name] = reordered;
+
+    autoSave();
+  }
+
+  draggedMarkerItem = null;
+}
+
+function seekToMarker(markerId, filename) {
+  const targetFile = filename || state.currentMedia?.name;
+  if (!targetFile) return;
+
+  // Switch to the file if different
+  if (state.currentMedia?.name !== targetFile) {
+    const file = state.mediaFiles.find(f => f.name === targetFile);
+    if (file) {
+      selectMedia(file);
+      // Wait for video to load, then seek
+      elements.videoPlayer.addEventListener('loadedmetadata', function onLoad() {
+        elements.videoPlayer.removeEventListener('loadedmetadata', onLoad);
+        const markers = state.markers[targetFile] || [];
+        const marker = markers.find(m => m.id === markerId);
+        if (marker) {
+          elements.videoPlayer.currentTime = marker.start;
+          elements.videoPlayer.play();
+        }
+      });
+      return;
+    }
+  }
+
+  const markers = state.markers[targetFile] || [];
+  const marker = markers.find(m => m.id === markerId);
+  if (marker) {
+    elements.videoPlayer.currentTime = marker.start;
+    elements.videoPlayer.play();
+  }
+}
+
+// ============================================================
+// Export Data Management
+// ============================================================
+
+function getClipDuration(source, markerId) {
+  const markers = state.markers[source] || [];
+  const marker = markers.find(m => m.id === markerId);
+  return marker ? marker.end - marker.start : 0;
+}
+
+function getTotalDuration() {
+  // Calculate total duration from all markers in order
+  let total = 0;
+  for (const filename of state.timeline.order) {
+    const markers = state.markers[filename] || [];
+    for (const m of markers) {
+      total += m.end - m.start;
+    }
+  }
+  // Add TTS duration
+  for (const clip of state.ttsClips) {
+    total = Math.max(total, clip.duration);
+  }
+  return total;
+}
+
+// ============================================================
+// TTS Generation
+// ============================================================
+
+// Emotion presets for combo box
+const EMOTION_PRESETS = [
+  { label: 'Confident', value: '用自信从容的语气说', desc: 'Opening hooks, key statements' },
+  { label: 'Clear & Sharp', value: '用清晰干练的语气说', desc: 'Walkthroughs, step-by-step' },
+  { label: 'Subtle Excitement', value: '用略带兴奋但克制的语气说', desc: 'Feature highlights' },
+  { label: 'Weary Sigh', value: '用无奈叹气的语气说', desc: 'Pain points, old way sucks' },
+  { label: 'Relaxed & Cheerful', value: '用轻松愉快的语气说', desc: 'CTA, closing' },
+  { label: 'Storytelling', value: '用娓娓道来的语气说', desc: 'Background, context' },
+  { label: 'Curious', value: '用好奇探索的语气说', desc: 'Questions, what-if' },
+  { label: 'Warm & Sincere', value: '用温暖真诚的语气说', desc: 'Personal touch, thanks' },
+];
+
+function initEmotionCombo() {
+  const input = elements.ttsEmotion;
+  const dropdown = elements.emotionDropdown;
+  const toggle = elements.emotionCombo.querySelector('.combo-toggle');
+
+  function renderOptions(filter = '') {
+    const lower = filter.toLowerCase();
+    const filtered = filter
+      ? EMOTION_PRESETS.filter(p => p.label.toLowerCase().includes(lower) || p.value.includes(filter))
+      : EMOTION_PRESETS;
+
+    dropdown.innerHTML = filtered.map(p => `
+      <li class="combo-option" data-value="${escapeHtml(p.value)}">
+        <span class="combo-option-label">${escapeHtml(p.label)}</span>
+        <span class="combo-option-desc">${escapeHtml(p.desc)}</span>
+      </li>
+    `).join('');
+
+    dropdown.querySelectorAll('.combo-option').forEach(li => {
+      li.addEventListener('mousedown', (e) => {
+        e.preventDefault();
+        input.value = li.dataset.value;
+        dropdown.classList.remove('open');
+      });
+    });
+  }
+
+  toggle.addEventListener('click', () => {
+    const isOpen = dropdown.classList.toggle('open');
+    if (isOpen) renderOptions(input.value);
+  });
+
+  input.addEventListener('focus', () => {
+    renderOptions(input.value);
+    dropdown.classList.add('open');
+  });
+
+  input.addEventListener('input', () => {
+    renderOptions(input.value);
+    dropdown.classList.add('open');
+  });
+
+  input.addEventListener('blur', () => {
+    setTimeout(() => dropdown.classList.remove('open'), 150);
+  });
+
+  // Initial render
+  renderOptions();
+}
+
+async function generateTTS() {
+  const text = elements.ttsText.value.trim();
+  if (!text) {
+    setStatus('Please enter narration text', true);
+    return;
+  }
+
+  const emotion = elements.ttsEmotion.value.trim();
+  let finalText = text;
+
+  // Add emotion marker if provided and not already present
+  if (emotion && !text.startsWith('[#')) {
+    finalText = `[#${emotion}]${text}`;
+  }
+
+  setStatus('Generating TTS...');
+  elements.btnGenerateTts.disabled = true;
+
+  try {
+    const ttsId = `tts_${Date.now()}`;
+    const outputFile = `${state.config.dir}/tts/${ttsId}.wav`;
+
+    const resp = await fetch(`${API_BASE}/recipes/volcengine_tts_with_emotion/run`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        params: {
+          text: finalText,
+          output_file: outputFile
+        }
+      })
+    });
+
+    const result = await resp.json();
+
+    if (result.status === 'completed' || result.status === 'ok') {
+      const ttsClip = {
+        id: ttsId,
+        text: text,
+        emotion: emotion,
+        audioFile: outputFile,
+        duration: (result.duration_ms || 3000) / 1000
+      };
+
+      state.ttsClips.push(ttsClip);
+      renderTTSList();
+      renderClipMarkers();  // Refresh to update TTS dropdown options
+      elements.ttsText.value = '';
+      setStatus('TTS generated successfully');
+
+      // Save TTS metadata
+      await saveTTSMetadata(ttsClip);
+    } else {
+      throw new Error(result.error || 'TTS generation failed');
+    }
+  } catch (e) {
+    console.error('TTS error:', e);
+    setStatus(`TTS error: ${e.message}`, true);
+  } finally {
+    elements.btnGenerateTts.disabled = false;
+  }
+}
+
+async function saveTTSMetadata(ttsClip) {
+  try {
+    await fetch(`${API_BASE}/file?path=${encodeURIComponent(state.config.dir + '/tts/' + ttsClip.id + '.json')}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: JSON.stringify(ttsClip, null, 2) })
+    });
+  } catch (e) {
+    console.error('Failed to save TTS metadata:', e);
+  }
+}
+
+function renderTTSList() {
+  if (state.ttsClips.length === 0) {
+    elements.ttsList.innerHTML = '<li class="empty-state">No narration clips yet</li>';
+    return;
+  }
+
+  elements.ttsList.innerHTML = state.ttsClips.map(clip => `
+    <li class="tts-item" data-tts-id="${clip.id}">
+      <div class="tts-text">${escapeHtml(clip.text)}</div>
+      <div class="tts-meta">
+        ${clip.emotion ? `<span class="tts-emotion">${clip.emotion}</span>` : ''}
+        <span class="tts-duration">${formatDuration(clip.duration)}</span>
+      </div>
+      <div class="tts-actions">
+        <button class="btn btn-small" onclick="playTTS('${clip.id}')" title="Play">▶</button>
+        <button class="btn btn-small btn-delete" onclick="deleteTTS('${clip.id}')" title="Delete">×</button>
+      </div>
+    </li>
+  `).join('');
+}
+
+function deleteTTS(ttsId) {
+  // Remove TTS from list
+  const index = state.ttsClips.findIndex(c => c.id === ttsId);
+  if (index === -1) return;
+
+  state.ttsClips.splice(index, 1);
+
+  // Clear any marker links to this TTS
+  for (const filename in state.markers) {
+    for (const marker of state.markers[filename]) {
+      if (marker.ttsId === ttsId) {
+        marker.ttsId = null;
+      }
+    }
+  }
+
+  renderTTSList();
+  renderClipMarkers();
+  autoSave();
+}
+
+function playTTS(ttsId) {
+  const clip = state.ttsClips.find(c => c.id === ttsId);
+  if (!clip) return;
+
+  const audio = new Audio(`${API_BASE}/file?path=${encodeURIComponent(clip.audioFile)}`);
+  audio.play();
+}
+
+// ============================================================
+// Save & Export
+// ============================================================
+
+async function saveProject() {
+  setStatus('Saving project...');
+
+  try {
+    // Save markers
+    await fetch(`${API_BASE}/file?path=${encodeURIComponent(state.config.dir + '/markers.json')}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: JSON.stringify(state.markers, null, 2) })
+    });
+
+    // Save timeline
+    await fetch(`${API_BASE}/file?path=${encodeURIComponent(state.config.dir + '/timeline.json')}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: JSON.stringify(state.timeline, null, 2) })
+    });
+
+    // Save TTS clips
+    await fetch(`${API_BASE}/file?path=${encodeURIComponent(state.config.dir + '/tts_clips.json')}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: JSON.stringify(state.ttsClips, null, 2) })
+    });
+
+    setStatus('Project saved');
+  } catch (e) {
+    console.error('Save error:', e);
+    setStatus('Failed to save project', true);
+  }
+}
+
+async function autoSave() {
+  // Debounced auto-save
+  if (state.autoSaveTimeout) clearTimeout(state.autoSaveTimeout);
+  state.autoSaveTimeout = setTimeout(saveProject, 2000);
+}
+
+async function exportVideo() {
+  // Collect all clips from markers in order
+  const allClips = [];
+  for (const filename of state.timeline.order) {
+    const markers = state.markers[filename] || [];
+    for (const marker of markers) {
+      // Find linked TTS
+      const linkedTts = marker.ttsId ? state.ttsClips.find(t => t.id === marker.ttsId) : null;
+      allClips.push({
+        source: filename,
+        markerId: marker.id,
+        start: marker.start,
+        end: marker.end,
+        ttsId: marker.ttsId,
+        ttsFile: linkedTts?.audioFile || null
+      });
+    }
+  }
+
+  if (allClips.length === 0) {
+    setStatus('No clip markers to export', true);
+    return;
+  }
+
+  elements.modalExport.classList.remove('hidden');
+  elements.exportProgress.style.width = '0%';
+  elements.exportStatus.textContent = 'Preparing clips...';
+
+  const tempDir = `${state.config.dir}/temp`;
+  const timestamp = Date.now();
+
+  try {
+    // Step 1: Trim each clip and optionally replace audio with TTS
+    const processedClips = [];
+    const totalSteps = allClips.length * 2 + 1; // trim + audio replace + merge
+    let currentStep = 0;
+
+    for (let i = 0; i < allClips.length; i++) {
+      const clip = allClips[i];
+      const inputFile = `${state.config.dir}/${clip.source}`;
+      const trimmedFile = `${tempDir}/trim_${timestamp}_${i}.mp4`;
+
+      // Step 1a: Trim the clip
+      elements.exportStatus.textContent = `Trimming clip ${i + 1}/${allClips.length}...`;
+
+      const trimResp = await fetch(`${API_BASE}/recipes/video_trim_clip/run`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          params: {
+            input_file: inputFile,
+            output_file: trimmedFile,
+            start: clip.start,
+            end: clip.end
+          }
+        })
+      });
+
+      const trimResult = await trimResp.json();
+      if (!trimResult.success && trimResult.data && !trimResult.data.success) {
+        throw new Error(trimResult.error || trimResult.data?.error || `Failed to trim clip ${i + 1}`);
+      }
+
+      currentStep++;
+      elements.exportProgress.style.width = `${(currentStep / totalSteps) * 100}%`;
+
+      let finalClipFile = trimmedFile;
+
+      // Step 1b: Replace audio with TTS if linked
+      if (clip.ttsFile) {
+        elements.exportStatus.textContent = `Adding TTS to clip ${i + 1}/${allClips.length}...`;
+
+        const withTtsFile = `${tempDir}/tts_${timestamp}_${i}.mp4`;
+
+        const audioResp = await fetch(`${API_BASE}/recipes/video_add_audio_track/run`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            params: {
+              video_file: trimmedFile,
+              audio_file: clip.ttsFile,
+              output_file: withTtsFile,
+              replace_audio: true
+            }
+          })
+        });
+
+        const audioResult = await audioResp.json();
+        if (!audioResult.success && audioResult.data && !audioResult.data.success) {
+          console.warn(`Failed to add TTS to clip ${i + 1}, using original audio`);
+        } else {
+          finalClipFile = withTtsFile;
+        }
+      }
+
+      currentStep++;
+      elements.exportProgress.style.width = `${(currentStep / totalSteps) * 100}%`;
+
+      processedClips.push(finalClipFile);
+    }
+
+    // Step 2: Merge all processed clips
+    elements.exportStatus.textContent = 'Merging video clips...';
+
+    const outputFile = `${state.config.dir}/output/final_${timestamp}.mp4`;
+
+    const mergeResp = await fetch(`${API_BASE}/recipes/video_merge_clips/run`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        params: {
+          clips: processedClips,
+          output_file: outputFile,
+          codec: 'libx264'  // Re-encode for compatibility
+        }
+      })
+    });
+
+    const mergeResult = await mergeResp.json();
+
+    if (!mergeResult.success && mergeResult.data && !mergeResult.data.success) {
+      throw new Error(mergeResult.error || mergeResult.data?.error || 'Video merge failed');
+    }
+
+    currentStep++;
+    elements.exportProgress.style.width = '100%';
+    elements.exportStatus.textContent = `Export complete!`;
+
+    // Show success with output path
+    setTimeout(() => {
+      elements.exportStatus.textContent = `Saved: ${outputFile}`;
+    }, 500);
+
+    setTimeout(() => {
+      elements.modalExport.classList.add('hidden');
+      setStatus(`Export complete: ${outputFile.split('/').pop()}`);
+    }, 3000);
+
+  } catch (e) {
+    console.error('Export error:', e);
+    elements.exportStatus.textContent = `Error: ${e.message}`;
+    setTimeout(() => {
+      elements.modalExport.classList.add('hidden');
+      setStatus(`Export failed: ${e.message}`, true);
+    }, 3000);
+  }
+}
+
+// ============================================================
+// Drag & Drop for Media List
+// ============================================================
+
+let draggedItem = null;
+
+function onDragStart(e) {
+  draggedItem = e.target;
+  e.target.classList.add('dragging');
+  e.dataTransfer.effectAllowed = 'move';
+}
+
+function onDragOver(e) {
+  e.preventDefault();
+  const item = e.target.closest('.media-item');
+  if (item && item !== draggedItem) {
+    const rect = item.getBoundingClientRect();
+    const midY = rect.top + rect.height / 2;
+    if (e.clientY < midY) {
+      item.parentNode.insertBefore(draggedItem, item);
+    } else {
+      item.parentNode.insertBefore(draggedItem, item.nextSibling);
+    }
+  }
+}
+
+function onDrop(e) {
+  e.preventDefault();
+}
+
+function onDragEnd(e) {
+  e.target.classList.remove('dragging');
+
+  // Update order in state
+  const items = elements.mediaList.querySelectorAll('.media-item');
+  state.timeline.order = Array.from(items).map(item => item.dataset.filename);
+  autoSave();
+}
+
+// ============================================================
+// Keyboard Shortcuts
+// ============================================================
+
+function onKeyDown(e) {
+  // Don't trigger shortcuts when typing in input fields
+  if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+
+  switch (e.key.toLowerCase()) {
+    case 'i':
+      markTime('start');
+      break;
+    case 'o':
+      markTime('end');
+      break;
+    case ' ':
+      e.preventDefault();
+      if (elements.videoPlayer.paused) {
+        elements.videoPlayer.play();
+      } else {
+        elements.videoPlayer.pause();
+      }
+      break;
+    case 'arrowleft':
+      elements.videoPlayer.currentTime -= e.shiftKey ? 5 : 1;
+      break;
+    case 'arrowright':
+      elements.videoPlayer.currentTime += e.shiftKey ? 5 : 1;
+      break;
+    case 's':
+      if (e.ctrlKey || e.metaKey) {
+        e.preventDefault();
+        saveProject();
+      }
+      break;
+  }
+}
+
+// ============================================================
+// Utility Functions
+// ============================================================
+
+function formatTime(seconds) {
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  const ms = Math.floor((seconds % 1) * 1000);
+  return `${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}.${ms.toString().padStart(3, '0')}`;
+}
+
+function formatDuration(seconds) {
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  const ms = Math.floor((seconds % 1) * 1000);
+  return `${m}:${s.toString().padStart(2, '0')}.${ms.toString().padStart(3, '0')}`;
+}
+
+function formatTimeShort(seconds) {
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  if (m > 0) {
+    return `${m}:${s.toString().padStart(2, '0')}`;
+  }
+  return `${s}s`;
+}
+
+function extractNumber(filename) {
+  const match = filename.match(/(\d+)/);
+  return match ? parseInt(match[1], 10) : null;
+}
+
+function escapeHtml(text) {
+  const div = document.createElement('div');
+  div.textContent = text;
+  return div.innerHTML;
+}
+
+function setStatus(message, isError = false) {
+  elements.statusMessage.textContent = message;
+  elements.statusMessage.style.color = isError ? 'var(--accent-red)' : 'var(--text-secondary)';
+}
+
+function updateTotalDuration() {
+  const total = getTotalDuration();
+  elements.statusDuration.textContent = `Total: ${formatDuration(total)}`;
+}
+
+function updateUI() {
+  renderMediaList();
+  renderClipMarkers();
+  renderTTSList();
+  updateTotalDuration();
+}
+
+// Make functions available globally for onclick handlers
+window.removeMarker = removeMarker;
+window.seekToMarker = seekToMarker;
+window.playTTS = playTTS;
+window.deleteTTS = deleteTTS;
+window.linkTtsToMarker = linkTtsToMarker;
+window.selectMediaByName = selectMediaByName;

--- a/community-recipes/recipes/video_cut_studio_ui/assets/index.html
+++ b/community-recipes/recipes/video_cut_studio_ui/assets/index.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Easy Clip</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="app">
+    <!-- Header -->
+    <header class="header">
+      <h1>Easy Clip</h1>
+      <div class="header-actions">
+        <button id="btn-save" class="btn btn-secondary">Save Project</button>
+        <button id="btn-export" class="btn btn-primary">Export Video</button>
+      </div>
+    </header>
+
+    <!-- Main Content -->
+    <main class="main">
+      <!-- Left Panel: Media List -->
+      <aside class="panel panel-left">
+        <div class="panel-header">
+          <h2>Media Files</h2>
+          <span class="badge" id="media-count">0</span>
+        </div>
+        <div class="panel-content">
+          <ul id="media-list" class="media-list"></ul>
+        </div>
+      </aside>
+
+      <!-- Center: Player & TTS -->
+      <section class="panel panel-center">
+        <!-- Video Player -->
+        <div class="player-container">
+          <video id="video-player" controls></video>
+          <div class="player-overlay" id="player-overlay">
+            <span>Select a media file to preview</span>
+          </div>
+        </div>
+
+        <!-- Waveform -->
+        <div class="waveform-container">
+          <canvas id="waveform-canvas"></canvas>
+          <div class="waveform-overlay">
+            <div class="playhead" id="playhead"></div>
+            <div class="markers" id="markers-overlay"></div>
+          </div>
+        </div>
+
+        <!-- Marker Controls -->
+        <div class="marker-controls">
+          <button id="btn-mark-start" class="btn btn-small">Mark Start [I]</button>
+          <span id="marker-preview">--:-- ~ --:--</span>
+          <button id="btn-mark-end" class="btn btn-small">Mark End [O]</button>
+          <button id="btn-add-marker" class="btn btn-small btn-accent" disabled>Add Marker</button>
+        </div>
+
+        <!-- TTS Section (replaces Timeline) -->
+        <div class="tts-container">
+          <div class="tts-header">
+            <h3>Narration TTS</h3>
+          </div>
+          <div class="tts-content">
+            <div class="tts-input-area">
+              <textarea id="tts-text" placeholder="Enter narration text (any language)..."></textarea>
+              <div class="tts-options">
+                <div class="combo-box" id="emotion-combo">
+                  <input type="text" id="tts-emotion" placeholder="Select or type emotion..." autocomplete="off">
+                  <button class="combo-toggle" type="button">▾</button>
+                  <ul class="combo-dropdown" id="emotion-dropdown"></ul>
+                </div>
+                <button id="btn-generate-tts" class="btn btn-accent">Generate TTS</button>
+              </div>
+            </div>
+            <div class="tts-clips-area">
+              <div class="tts-clips-header">Generated Clips</div>
+              <ul id="tts-list" class="tts-list">
+                <li class="empty-state">No narration clips yet</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Right Panel: Clip Markers Only -->
+      <aside class="panel panel-right">
+        <div class="panel-header">
+          <h2>Clip Markers</h2>
+          <span class="badge" id="marker-count">0</span>
+        </div>
+        <div class="panel-subheader">
+          <span>Drag to reorder</span>
+        </div>
+        <div class="panel-content">
+          <ul id="clip-markers" class="marker-list sortable">
+            <li class="empty-state">No markers yet. Select a media file and mark clips.</li>
+          </ul>
+        </div>
+      </aside>
+    </main>
+
+    <!-- Status Bar -->
+    <footer class="status-bar">
+      <span id="status-message">Ready</span>
+      <span id="status-duration">Total: 00:00</span>
+    </footer>
+  </div>
+
+  <!-- Modal for export progress -->
+  <div id="modal-export" class="modal hidden">
+    <div class="modal-content">
+      <h3>Exporting Video</h3>
+      <div class="progress-bar">
+        <div class="progress-fill" id="export-progress"></div>
+      </div>
+      <p id="export-status">Preparing...</p>
+    </div>
+  </div>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/community-recipes/recipes/video_cut_studio_ui/assets/style.css
+++ b/community-recipes/recipes/video_cut_studio_ui/assets/style.css
@@ -1,0 +1,900 @@
+/* Video Clip Annotator - Dark Theme */
+
+:root {
+  --bg-primary: #0d1117;
+  --bg-secondary: #161b22;
+  --bg-tertiary: #21262d;
+  --bg-hover: #30363d;
+  --border-color: #30363d;
+  --text-primary: #e6edf3;
+  --text-secondary: #8b949e;
+  --text-muted: #6e7681;
+  --accent-blue: #58a6ff;
+  --accent-green: #3fb950;
+  --accent-red: #f85149;
+  --accent-orange: #d29922;
+  --accent-purple: #a371f7;
+  --track-video: #238636;
+  --track-narration: #1f6feb;
+  --marker-color: #f0883e;
+  --playhead-color: #ff7b72;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--text-primary);
+  background: var(--bg-primary);
+  overflow: hidden;
+}
+
+/* Layout */
+.app {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.header h1 {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.header-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.main {
+  display: flex;
+  flex: 1;
+  overflow: visible;
+}
+
+/* Panels */
+.panel {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-secondary);
+  border-right: 1px solid var(--border-color);
+}
+
+.panel-left {
+  width: 240px;
+  min-width: 200px;
+}
+
+.panel-center {
+  flex: 1;
+  border-right: 1px solid var(--border-color);
+}
+
+.panel-right {
+  width: 300px;
+  min-width: 260px;
+  border-right: none;
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.panel-header h2 {
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-secondary);
+}
+
+.panel-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+}
+
+.panel-section {
+  border-bottom: 1px solid var(--border-color);
+}
+
+.panel-section:last-child {
+  border-bottom: none;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.panel-section .panel-content {
+  padding: 12px;
+}
+
+/* Buttons */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 12px;
+  font-size: 13px;
+  font-weight: 500;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.btn:hover {
+  background: var(--bg-hover);
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-primary {
+  background: var(--accent-green);
+  border-color: var(--accent-green);
+  color: #fff;
+}
+
+.btn-primary:hover {
+  background: #2ea043;
+}
+
+.btn-secondary {
+  background: var(--bg-tertiary);
+}
+
+.btn-accent {
+  background: var(--accent-blue);
+  border-color: var(--accent-blue);
+  color: #fff;
+}
+
+.btn-accent:hover {
+  background: #4c9aed;
+}
+
+.btn-small {
+  padding: 4px 8px;
+  font-size: 12px;
+}
+
+.btn-icon {
+  width: 28px;
+  height: 28px;
+  padding: 0;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  font-size: 11px;
+  font-weight: 600;
+  border-radius: 10px;
+  background: var(--bg-hover);
+  color: var(--text-secondary);
+}
+
+/* Media List */
+.media-list {
+  list-style: none;
+}
+
+.media-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.media-item:hover {
+  background: var(--bg-hover);
+}
+
+.media-item.active {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--accent-blue);
+}
+
+.media-item.dragging {
+  opacity: 0.5;
+}
+
+.media-item .drag-handle {
+  color: var(--text-muted);
+  cursor: grab;
+}
+
+.media-item .media-icon {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  background: var(--bg-hover);
+  font-size: 14px;
+}
+
+.media-item .media-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.media-item .media-name {
+  font-size: 13px;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.media-item .media-duration {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.media-item .media-markers {
+  font-size: 11px;
+  color: var(--marker-color);
+}
+
+/* Video Player */
+.player-container {
+  position: relative;
+  background: #000;
+  aspect-ratio: 16 / 9;
+  max-height: 45vh;
+}
+
+.player-container video {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.player-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-primary);
+  color: var(--text-muted);
+}
+
+.player-overlay.hidden {
+  display: none;
+}
+
+/* Waveform */
+.waveform-container {
+  position: relative;
+  height: 80px;
+  background: var(--bg-tertiary);
+  border-top: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.waveform-container canvas {
+  width: 100%;
+  height: 100%;
+}
+
+.waveform-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.playhead {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--playhead-color);
+  transform: translateX(-1px);
+  z-index: 10;
+}
+
+.playhead::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -4px;
+  width: 10px;
+  height: 10px;
+  background: var(--playhead-color);
+  clip-path: polygon(50% 100%, 0 0, 100% 0);
+}
+
+.marker-region {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  background: rgba(240, 136, 62, 0.3);
+  border-left: 2px solid var(--marker-color);
+  border-right: 2px solid var(--marker-color);
+}
+
+/* Marker Controls */
+.marker-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 8px 16px;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
+}
+
+#marker-preview {
+  font-family: 'SF Mono', Monaco, 'Courier New', monospace;
+  font-size: 13px;
+  color: var(--text-secondary);
+  min-width: 120px;
+  text-align: center;
+}
+
+/* TTS Container (replaces Timeline) */
+.tts-container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 180px;
+  background: var(--bg-primary);
+}
+
+.tts-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.tts-header h3 {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.tts-content {
+  flex: 1;
+  display: flex;
+  gap: 16px;
+  padding: 16px;
+  overflow: visible;
+}
+
+.tts-input-area {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.tts-input-area textarea {
+  flex: 1;
+  min-height: 80px;
+  padding: 12px;
+  font-size: 13px;
+  font-family: inherit;
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  resize: none;
+}
+
+.tts-input-area textarea:focus {
+  outline: none;
+  border-color: var(--accent-blue);
+}
+
+.tts-input-area textarea::placeholder {
+  color: var(--text-muted);
+}
+
+.tts-input-area .tts-options {
+  display: flex;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.tts-input-area .tts-options select {
+  flex: 1;
+  padding: 8px 12px;
+  font-size: 13px;
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+}
+
+.tts-clips-area {
+  width: 280px;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-secondary);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.tts-clips-header {
+  padding: 10px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.tts-clips-area .tts-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+}
+
+/* Panel subheader */
+.panel-subheader {
+  padding: 6px 16px;
+  font-size: 11px;
+  color: var(--text-muted);
+  background: var(--bg-tertiary);
+  border-bottom: 1px solid var(--border-color);
+}
+
+/* Marker List */
+.marker-list {
+  list-style: none;
+}
+
+.marker-list .empty-state,
+.tts-list .empty-state {
+  padding: 20px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+/* Marker Group (file header) */
+.marker-group {
+  list-style: none;
+  margin-top: 8px;
+}
+
+.marker-group:first-child {
+  margin-top: 0;
+}
+
+.marker-group-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 10px;
+  background: var(--bg-secondary);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+  color: var(--text-secondary);
+  transition: background 0.15s ease;
+}
+
+.marker-group-header:hover {
+  background: var(--bg-hover);
+}
+
+.marker-group.active .marker-group-header {
+  background: var(--bg-hover);
+  color: var(--accent-blue);
+}
+
+.marker-group-name {
+  font-weight: 500;
+}
+
+.marker-group-count {
+  background: var(--bg-tertiary);
+  padding: 2px 6px;
+  border-radius: 10px;
+  font-size: 11px;
+}
+
+.marker-item.current-file {
+  border-left: 2px solid var(--accent-blue);
+}
+
+.marker-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 6px;
+  margin-bottom: 6px;
+  background: var(--bg-tertiary);
+  cursor: grab;
+  transition: all 0.15s ease;
+}
+
+.marker-item:hover {
+  background: var(--bg-hover);
+}
+
+.marker-item.dragging {
+  opacity: 0.5;
+  background: var(--bg-hover);
+}
+
+.marker-item .drag-handle {
+  color: var(--text-muted);
+  font-size: 12px;
+  cursor: grab;
+}
+
+.marker-item .marker-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.marker-item .marker-time {
+  font-family: 'SF Mono', Monaco, 'Courier New', monospace;
+  font-size: 12px;
+  color: var(--marker-color);
+}
+
+.marker-item .marker-duration {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.marker-item .marker-tts-link {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+.marker-item .tts-select {
+  flex: 1;
+  padding: 4px 6px;
+  font-size: 11px;
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  max-width: 160px;
+}
+
+.marker-item .tts-select:focus {
+  outline: none;
+  border-color: var(--accent-blue);
+}
+
+.marker-item .marker-actions {
+  display: flex;
+  gap: 4px;
+}
+
+.marker-item .btn-delete {
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  font-size: 14px;
+  color: var(--accent-red);
+  background: transparent;
+  border: none;
+}
+
+.marker-item .btn-delete:hover {
+  background: rgba(248, 81, 73, 0.2);
+}
+
+/* TTS Section */
+.tts-form {
+  margin-bottom: 12px;
+}
+
+.tts-form textarea {
+  width: 100%;
+  height: 100px;
+  padding: 10px;
+  font-size: 13px;
+  font-family: inherit;
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  resize: vertical;
+}
+
+.tts-form textarea:focus {
+  outline: none;
+  border-color: var(--accent-blue);
+}
+
+.tts-form textarea::placeholder {
+  color: var(--text-muted);
+}
+
+.tts-options {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.tts-options select {
+  flex: 1;
+  padding: 6px 10px;
+  font-size: 13px;
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+}
+
+.tts-options select:focus {
+  outline: none;
+  border-color: var(--accent-blue);
+}
+
+.tts-list {
+  list-style: none;
+  flex: 1;
+  overflow-y: auto;
+}
+
+.tts-item {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px;
+  border-radius: 6px;
+  margin-bottom: 6px;
+  background: var(--bg-tertiary);
+}
+
+.tts-item .tts-text {
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.tts-item .tts-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.tts-item .tts-emotion {
+  color: var(--accent-purple);
+}
+
+.tts-item .tts-duration {
+  color: var(--accent-blue);
+}
+
+.tts-item .tts-actions {
+  display: flex;
+  gap: 4px;
+}
+
+/* Status Bar */
+.status-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 16px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  background: var(--bg-secondary);
+  border-top: 1px solid var(--border-color);
+}
+
+/* Modal */
+.modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.7);
+  z-index: 1000;
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal-content {
+  width: 400px;
+  padding: 24px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+}
+
+.modal-content h3 {
+  margin-bottom: 16px;
+  font-size: 16px;
+}
+
+.progress-bar {
+  height: 8px;
+  background: var(--bg-tertiary);
+  border-radius: 4px;
+  overflow: hidden;
+  margin-bottom: 12px;
+}
+
+.progress-fill {
+  height: 100%;
+  width: 0%;
+  background: var(--accent-green);
+  transition: width 0.3s ease;
+}
+
+#export-status {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+/* Scrollbar */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--bg-primary);
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--bg-hover);
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--border-color);
+}
+
+/* Drag and Drop */
+.drag-over {
+  background: var(--bg-hover) !important;
+}
+
+.drop-indicator {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--accent-blue);
+  pointer-events: none;
+}
+
+/* Combo Box */
+.combo-box {
+  position: relative;
+  flex: 1;
+  display: flex;
+}
+
+.combo-box input {
+  flex: 1;
+  padding: 8px 32px 8px 12px;
+  font-size: 13px;
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  min-width: 0;
+}
+
+.combo-box input:focus {
+  outline: none;
+  border-color: var(--accent-blue);
+}
+
+.combo-box input::placeholder {
+  color: var(--text-muted);
+}
+
+.combo-toggle {
+  position: absolute;
+  right: 4px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  font-size: 11px;
+  color: var(--text-muted);
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.combo-toggle:hover {
+  color: var(--text-primary);
+}
+
+.combo-dropdown {
+  display: none;
+  position: absolute;
+  bottom: 40px;
+  left: 0;
+  right: 0;
+  max-height: 240px;
+  overflow-y: auto;
+  list-style: none;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 4px;
+  z-index: 9999;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+
+.combo-dropdown.open {
+  display: block;
+}
+
+.combo-option {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.combo-option:hover {
+  background: var(--bg-hover);
+}
+
+.combo-option-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.combo-option-desc {
+  font-size: 11px;
+  color: var(--text-muted);
+}

--- a/community-recipes/recipes/video_cut_studio_ui/recipe.md
+++ b/community-recipes/recipes/video_cut_studio_ui/recipe.md
@@ -1,0 +1,96 @@
+---
+name: video_cut_studio_ui
+type: atomic
+runtime: shell
+version: "1.0.0"
+description: "视频剪辑工作台的静态 UI 资源，包含 HTML/JS/CSS 文件"
+use_cases:
+  - "被 video_cut_studio workflow 配方复制使用"
+  - "提供视频播放、波形显示、时间轴标注、TTS 生成等前端功能"
+output_targets:
+  - stdout
+tags:
+  - video
+  - editor
+  - annotation
+  - ui
+inputs:
+  target_dir:
+    type: string
+    required: true
+    description: "目标目录路径"
+outputs:
+  success:
+    type: boolean
+    description: "是否成功复制"
+dependencies: []
+---
+
+# video_cut_studio_ui
+
+## 功能描述
+
+视频剪辑工作台的静态前端资源包，包含完整的 HTML/JS/CSS 文件。
+
+此配方为纯静态资源，由 `video_cut_studio` workflow 配方在运行时复制到 viewer content 目录使用。
+
+## 文件结构
+
+```
+assets/
+├── index.html    # 主页面
+├── app.js        # 应用逻辑
+└── style.css     # 样式表
+```
+
+## UI 功能模块
+
+### 左侧面板 - 素材列表
+- 显示目录中的媒体文件
+- 按文件名编号自动排序
+- 支持拖拽调整顺序
+- 显示每个素材的标记数量
+
+### 中间区域 - 播放器与时间轴
+- HTML5 视频播放器
+- Web Audio API 音频波形可视化
+- 播放头位置指示
+- 标记区域高亮
+- 多轨时间轴编排（视频轨 + 旁白轨）
+- 时间刻度尺
+
+### 右侧面板 - 标注与 TTS
+- 当前素材的标记列表
+- 标记时间点显示
+- 添加到时间轴按钮
+- TTS 文本输入区
+- 情感选择下拉菜单
+- TTS 生成按钮
+- 已生成的旁白列表
+
+## 键盘快捷键
+
+| 按键 | 功能 |
+|------|------|
+| `I` | 标记起始点 |
+| `O` | 标记结束点 |
+| `Space` | 播放/暂停 |
+| `←` | 后退 1 秒 |
+| `→` | 前进 1 秒 |
+| `Shift+←` | 后退 5 秒 |
+| `Shift+→` | 前进 5 秒 |
+| `Ctrl+S` | 保存项目 |
+
+## API 依赖
+
+前端通过 frago server API 进行数据交互：
+
+- `GET /api/file?path=...` - 读取文件/目录
+- `POST /api/file?path=...` - 写入文件
+- `POST /api/recipes/{name}/run` - 执行配方（TTS、视频合并）
+
+## 注意事项
+
+- 此配方不直接运行，仅作为资源包被其他配方使用
+- 需要 frago server 运行中才能正常工作
+- 波形绘制使用 Web Audio API，部分格式可能不支持

--- a/community-recipes/recipes/video_cut_studio_ui/recipe.sh
+++ b/community-recipes/recipes/video_cut_studio_ui/recipe.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Recipe: video_cut_studio_ui
+# Description: 复制 UI 资源到目标目录
+
+set -e
+
+# Parse JSON input
+INPUT="${1:-{}}"
+TARGET_DIR=$(echo "$INPUT" | python3 -c "import sys, json; print(json.load(sys.stdin).get('target_dir', ''))")
+
+if [ -z "$TARGET_DIR" ]; then
+    echo '{"success": false, "error": "缺少必需参数: target_dir"}'
+    exit 1
+fi
+
+# Get script directory (where assets folder is)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ASSETS_DIR="$SCRIPT_DIR/assets"
+
+if [ ! -d "$ASSETS_DIR" ]; then
+    echo '{"success": false, "error": "assets 目录不存在"}'
+    exit 1
+fi
+
+# Create target directory
+mkdir -p "$TARGET_DIR"
+
+# Copy assets
+cp -r "$ASSETS_DIR"/* "$TARGET_DIR/"
+
+echo "{\"success\": true, \"target_dir\": \"$TARGET_DIR\", \"files\": [\"index.html\", \"app.js\", \"style.css\"]}"


### PR DESCRIPTION
## New Recipe: video_cut_studio_ui

**Type:** atomic
**Runtime:** shell
**Version:** 1.0.0

### Description

视频剪辑工作台的静态 UI 资源，包含 HTML/JS/CSS 文件

### Use Cases

- 被 video_cut_studio workflow 配方复制使用
- 提供视频播放、波形显示、时间轴标注、TTS 生成等前端功能

---

*Submitted via `frago recipe share`*
