### PR TITLE
feat(taskboard): four-applier interface + scheduled ingest fast-path (Phase 1 part A)

### DIFF
--- a/src/frago/server/services/pa_validators.py
+++ b/src/frago/server/services/pa_validators.py
@@ -11,7 +11,13 @@ import json
 from dataclasses import dataclass, field
 from typing import Any
 
-VALID_PA_ACTIONS = {"reply", "run", "resume", "schedule"}
+# spec freeze v1.1 §3: PA 对 Msg 输出的 action 词汇集 = {run, reply, resume, dismiss} 4 个
+# schedule 是 PA 全局 action (注册 cron), 走独立 SchedulerService 通路, 不在 Msg loop 内.
+# Phase 1: 加 dismiss; schedule 暂保留兼容 (Phase 1 后续 commit 与 scheduler 改造同步移除).
+VALID_PA_ACTIONS = {"reply", "run", "resume", "dismiss", "schedule"}
+
+# Msg-action 词汇 (spec freeze v1.1 §3 严格 4 个, 用于 DecisionApplier 路由)
+VALID_MSG_ACTIONS = {"run", "reply", "resume", "dismiss"}
 
 VALID_QUEUE_MESSAGE_TYPES = {
     "user_message",
@@ -32,8 +38,30 @@ _PA_ACTION_REQUIRED_FIELDS: dict[str, list[str]] = {
     "reply": ["channel", "text"],       # + task_id OR msg_id (checked separately)
     "run": ["channel", "description", "prompt"],  # + task_id OR msg_id
     "resume": ["task_id", "prompt"],    # always task_id
+    "dismiss": ["msg_id"],              # spec v1.1: PA 显式放弃 msg, 不创建 task
     "schedule": ["name", "prompt"],     # + cron OR every (checked in handler)
 }
+
+
+def validate_prompt_format(prompt: str) -> str | None:
+    """spec freeze v1.1 §3 prompt 格式契约: 首行 ≤80 字摘要 + 空行 + 正文.
+
+    Applier 调用此函数, 不符则 reject(reason=prompt_format_invalid).
+    返回 None = 合法; 返回 str = 非法理由.
+    """
+    if not prompt:
+        return "prompt is empty"
+    parts = prompt.split("\n", 2)
+    if len(parts) < 2:
+        return "prompt missing newline (need '首行摘要\\n\\n正文')"
+    first_line = parts[0]
+    if len(first_line) > 80:
+        return f"first line length {len(first_line)} > 80 chars"
+    if "```" in first_line:
+        return "first line contains code fence"
+    if len(parts) >= 2 and parts[1].strip() != "":
+        return "missing blank line between summary and body"
+    return None
 
 # Actions that require either task_id or msg_id
 _ACTIONS_REQUIRING_ID: set[str] = {"reply", "run", "schedule"}

--- a/src/frago/server/services/taskboard/applier.py
+++ b/src/frago/server/services/taskboard/applier.py
@@ -1,0 +1,41 @@
+"""BaseApplier: 抽象基类, 四个 Applier 共享 reject + record_rejection 逻辑。
+
+四个具体 Applier:
+- Ingestor (taskboard/ingestor.py) — 外部信道 & scheduled trigger ingress
+- DecisionApplier (taskboard/decision_applier.py) — PA decisions JSON 路由
+- ExecutionApplier (taskboard/execution_applier.py) — Executor 启动 / 完成回写
+- ResumeApplier (taskboard/resume_applier.py) — resume action 三档路由
+
+公共职责: 状态机校验 reject + record_rejection 写 timeline + 推 recent_rejections 滚动窗口。
+"""
+
+from __future__ import annotations
+
+from frago.server.services.taskboard.board import TaskBoard
+
+
+class BaseApplier:
+    """Applier 抽象基类。"""
+
+    name: str = "applier"
+
+    def __init__(self, board: TaskBoard):
+        self._board = board
+
+    def _reject(
+        self,
+        *,
+        reason: str,
+        offending_msg_id: str | None = None,
+        offending_task_id: str | None = None,
+        original_action: str = "",
+        original_prompt_head: str = "",
+    ) -> None:
+        """走 board.record_rejection 写 decision_rejected timeline + 推 recent_rejections."""
+        self._board.record_rejection(
+            reason=reason,
+            offending_msg_id=offending_msg_id,
+            offending_task_id=offending_task_id,
+            original_action=original_action,
+            original_prompt_head=original_prompt_head,
+        )

--- a/src/frago/server/services/taskboard/decision_applier.py
+++ b/src/frago/server/services/taskboard/decision_applier.py
@@ -1,0 +1,116 @@
+"""DecisionApplier: PA decisions JSON 路由器。
+
+接收 PA 输出 list[dict], 按 action 词汇 (run/reply/resume/dismiss) 路由:
+- 词汇校验 → reject reason=action_invalid
+- prompt 格式校验 (首行 ≤80 + 空行 + 正文) → reject reason=prompt_format_invalid
+- 状态机校验 (msg.status / task.status) → board 公有方法内部抛 IllegalTransitionError, 已 record_rejection
+- 路由: run → append_task(type=run); reply → append_task(type=reply) + lifecycle.send_reply + mark_task_replied + close_msg_if_terminal; resume → ResumeApplier.route_resume; dismiss → board.mark_msg_dismissed
+
+Phase 1 范围: 接口 + 词汇路由 + prompt 格式校验 + 集成 ResumeApplier。
+Phase 1 后续 commit: PA wire-up (primary_agent_service._handle_pa_output 改调本类) + reply 推送集成 task_lifecycle。
+"""
+
+from __future__ import annotations
+
+from frago.server.services.taskboard.applier import BaseApplier
+from frago.server.services.taskboard.board import TaskBoard
+from frago.server.services.taskboard.models import (
+    IllegalTransitionError,
+    Intent,
+)
+from frago.server.services.taskboard.resume_applier import ResumeApplier
+
+# 4 action 词汇集 (Phase 1 freeze v1.1 §3 — 不含 schedule, schedule 走独立 SchedulerService 通路)
+VALID_MSG_ACTIONS = {"run", "reply", "resume", "dismiss"}
+
+
+class DecisionApplier(BaseApplier):
+    name = "DecisionApplier"
+
+    def __init__(self, board: TaskBoard, resume_applier: ResumeApplier | None = None):
+        super().__init__(board)
+        self._resume_applier = resume_applier or ResumeApplier(board)
+
+    def handle_pa_output(self, decisions: list[dict]) -> None:
+        """主路由入口, 接收 PA 输出 list[dict]."""
+        for d in decisions:
+            self._handle_one(d)
+
+    def _handle_one(self, d: dict) -> None:
+        action = d.get("action")
+        if action not in VALID_MSG_ACTIONS:
+            self._reject(
+                reason="action_invalid",
+                offending_msg_id=d.get("msg_id"),
+                offending_task_id=d.get("task_id"),
+                original_action=str(action or ""),
+                original_prompt_head=(d.get("prompt") or "").split("\n", 1)[0][:80],
+            )
+            return
+
+        prompt = d.get("prompt", "")
+        if action in {"run", "reply", "resume"}:
+            err = validate_prompt_format(prompt)
+            if err:
+                self._reject(
+                    reason="prompt_format_invalid",
+                    offending_msg_id=d.get("msg_id"),
+                    offending_task_id=d.get("task_id"),
+                    original_action=action,
+                    original_prompt_head=prompt.split("\n", 1)[0][:80],
+                )
+                return
+
+        msg_id = d.get("msg_id")
+        task_id = d.get("task_id")
+
+        try:
+            if action == "run":
+                self._board.append_task(
+                    msg_id, Intent(prompt=prompt), task_type="run", by=self.name
+                )
+            elif action == "reply":
+                task = self._board.append_task(
+                    msg_id, Intent(prompt=prompt), task_type="reply", by=self.name
+                )
+                # Phase 1 后续 commit: lifecycle.send_reply(channel, payload) 集成
+                # 当前仅落 task + mark_replied + close_msg, 不实际推送
+                self._board.mark_task_replied(task.task_id, by=self.name) if hasattr(
+                    self._board, "mark_task_replied"
+                ) else None
+                self._board.close_msg_if_terminal(msg_id, by=self.name) if hasattr(
+                    self._board, "close_msg_if_terminal"
+                ) else None
+            elif action == "resume":
+                self._resume_applier.route_resume(task_id, prompt)
+            elif action == "dismiss":
+                if hasattr(self._board, "mark_msg_dismissed"):
+                    self._board.mark_msg_dismissed(
+                        msg_id, reason=prompt or "(no reason)", by=self.name
+                    )
+                # Phase 1 后续 commit: board.mark_msg_dismissed 公有方法实装
+        except IllegalTransitionError:
+            # board 内部已 record_rejection, 不重复
+            pass
+
+
+def validate_prompt_format(prompt: str) -> str | None:
+    """校验 PA prompt 格式: 首行 ≤80 字摘要 + 空行 + 正文。
+
+    返回 None = 合法; 返回 str = 非法理由。
+    Phase 1 范围: 严格校验首行长度 + 含空行分隔。
+    """
+    if not prompt:
+        return "prompt is empty"
+    parts = prompt.split("\n", 2)
+    if len(parts) < 2:
+        return "prompt missing newline (need '首行摘要\\n\\n正文')"
+    first_line = parts[0]
+    if len(first_line) > 80:
+        return f"first line length {len(first_line)} > 80 chars"
+    if "```" in first_line:
+        return "first line contains code fence"
+    # 第二行必须是空 (摘要 + 空行 + 正文)
+    if len(parts) >= 2 and parts[1].strip() != "":
+        return "missing blank line between summary and body"
+    return None

--- a/src/frago/server/services/taskboard/execution_applier.py
+++ b/src/frago/server/services/taskboard/execution_applier.py
@@ -1,0 +1,101 @@
+"""ExecutionApplier: Executor 启动 / 完成回写 board.
+
+Phase 1 接口:
+- start_task(task_id, run_id, pid, csid) — Executor spawn 后调
+- finish_task(task_id, result, error) — sub-agent 完成 / 失败时调
+
+Phase 1 后续 commit: executor.py 集成 (从 TaskStore 改调本类)。
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from frago.server.services.taskboard.applier import BaseApplier
+from frago.server.services.taskboard.models import (
+    IllegalTransitionError,
+    Result,
+    Session,
+)
+
+
+class ExecutionApplier(BaseApplier):
+    name = "ExecutionApplier"
+
+    def start_task(
+        self,
+        task_id: str,
+        *,
+        run_id: str,
+        pid: int,
+        csid: str | None,
+        started_at: datetime | None = None,
+    ) -> None:
+        with self._board._lock:
+            task = self._board._find_task(task_id)
+            if task is None:
+                self._reject(
+                    reason="task_not_found",
+                    offending_task_id=task_id,
+                    original_action="start_task",
+                )
+                return
+            if task.status not in {"queued", "executing"}:
+                self._reject(
+                    reason="illegal_transition",
+                    offending_task_id=task_id,
+                    original_action="start_task",
+                )
+                raise IllegalTransitionError(
+                    f"task {task_id}.status={task.status} cannot start"
+                )
+            task.status = "executing"
+            task.session = Session(
+                run_id=run_id,
+                claude_session_id=csid,
+                pid=pid,
+                started_at=started_at or datetime.now().astimezone(),
+            )
+            self._board._timeline.append_entry(
+                data_type="task_started",
+                by=self.name,
+                task_id=task_id,
+                data={"run_id": run_id, "pid": pid, "csid": csid},
+            )
+
+    def finish_task(
+        self,
+        task_id: str,
+        *,
+        result_summary: str = "",
+        error: str | None = None,
+        status: str = "completed",
+    ) -> None:
+        with self._board._lock:
+            task = self._board._find_task(task_id)
+            if task is None:
+                self._reject(
+                    reason="task_not_found",
+                    offending_task_id=task_id,
+                    original_action="finish_task",
+                )
+                return
+            if task.status != "executing":
+                self._reject(
+                    reason="illegal_transition",
+                    offending_task_id=task_id,
+                    original_action="finish_task",
+                )
+                raise IllegalTransitionError(
+                    f"task {task_id}.status={task.status} cannot finish"
+                )
+            task.status = "completed" if status == "completed" else "failed"  # type: ignore[assignment]
+            if task.session is not None:
+                task.session.ended_at = datetime.now().astimezone()
+            task.result = Result(summary=result_summary, error=error)
+            self._board._timeline.append_entry(
+                data_type="task_finished",
+                by=self.name,
+                task_id=task_id,
+                data={"status": task.status, "result_summary": result_summary, "error": error},
+            )

--- a/src/frago/server/services/taskboard/ingestor.py
+++ b/src/frago/server/services/taskboard/ingestor.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 from datetime import datetime
 
 from frago.server.services.taskboard.board import TaskBoard
-from frago.server.services.taskboard.models import Msg, Source
+from frago.server.services.taskboard.models import Intent, Msg, Source
+from frago.server.services.taskboard.timeline import ulid_new
 
 
 class Ingestor:
@@ -45,4 +46,47 @@ class Ingestor:
             ),
         )
         self._board.append_msg(thread_id, msg, by="Ingestor")
+        return msg
+
+    def ingest_scheduled(
+        self,
+        *,
+        schedule_id: str,
+        prompt: str,
+        trigger_at: datetime,
+        job_name: str,
+    ) -> Msg:
+        """scheduled trigger fast-path (Yi B1 / Gap 3a 修订).
+
+        - thread 不归并, 每次触发独立 (origin=scheduled, subkind=job_name)
+        - Msg 状态: 通过 append_msg 进 received → append_task 自动转 dispatched
+          (Phase 1 后续 commit 改成 真正 fast-path: Msg 直接 dispatched 跳过 awaiting_decision)
+        - Source default: sender_id='__scheduler__', parent_ref=schedule_id
+        - 同 transaction append type=run task with intent.prompt=锁定值
+        """
+        thread_id = ulid_new()
+        self._board.create_thread(
+            thread_id=thread_id,
+            origin="scheduled",
+            subkind=job_name,
+            root_summary=prompt.split("\n", 1)[0][:80],
+            by="Ingestor",
+            created_at=trigger_at,
+        )
+        msg = Msg(
+            msg_id=f"scheduled:{schedule_id}:{trigger_at.isoformat()}",
+            status="awaiting_decision",  # 经过 append_task 后会转 dispatched
+            source=Source(
+                channel="scheduled",
+                text=prompt,
+                sender_id="__scheduler__",
+                parent_ref=schedule_id,
+                received_at=trigger_at,
+                reply_context=None,
+            ),
+        )
+        self._board.append_msg(thread_id, msg, by="Ingestor")
+        self._board.append_task(
+            msg.msg_id, Intent(prompt=prompt), task_type="run", by="Ingestor"
+        )
         return msg

--- a/src/frago/server/services/taskboard/resume_applier.py
+++ b/src/frago/server/services/taskboard/resume_applier.py
@@ -1,0 +1,134 @@
+"""ResumeApplier: resume action 三档路由器。
+
+按 task.status 分流:
+- completed / failed (session 已结束) → Case A: Executor.spawn_resume(csid, prompt) → 新 run_id, CSID 沿用
+- executing (session 在跑) → Case B: ResumeInbox.enqueue + board.record_resume_pending (复用 spec 20260501)
+- queued / replied / not_found → reject
+
+Case A CSID 失效 (ClaudeSessionNotFoundError) → task.status=resume_failed (新终态) + timeline resume_csid_lost.
+
+Phase 1 stage-gate: Case A 默认 disabled (FRAGO_CASE_A_ENABLED=1 才启用),
+未启用期 resume completed/failed task → reject(reason=case_a_not_implemented).
+"""
+
+from __future__ import annotations
+
+import os
+
+from frago.server.services.taskboard.applier import BaseApplier
+from frago.server.services.taskboard.models import ClaudeSessionNotFoundError
+
+
+def case_a_enabled() -> bool:
+    """Phase 1 灰度开关. 默认 False, 通过 env var 显式启用。"""
+    return os.environ.get("FRAGO_CASE_A_ENABLED", "0") == "1"
+
+
+class ResumeApplier(BaseApplier):
+    name = "ResumeApplier"
+
+    def __init__(self, board, executor=None, resume_inbox=None):
+        super().__init__(board)
+        self._executor = executor  # Phase 1 后续 commit 注入实际 Executor
+        self._resume_inbox = resume_inbox  # Phase 1 后续 commit 注入 ResumeInbox
+
+    def route_resume(self, task_id: str | None, prompt: str) -> None:
+        if not task_id:
+            self._reject(
+                reason="task_id_missing",
+                original_action="resume",
+                original_prompt_head=prompt.split("\n", 1)[0][:80] if prompt else "",
+            )
+            return
+
+        task = self._board._find_task(task_id)
+        if task is None:
+            self._reject(
+                reason="task_not_found",
+                offending_task_id=task_id,
+                original_action="resume",
+                original_prompt_head=prompt.split("\n", 1)[0][:80] if prompt else "",
+            )
+            return
+
+        # 非法状态: queued / replied / resume_failed
+        if task.status in {"queued", "replied", "resume_failed"}:
+            self._reject(
+                reason="resume_illegal_state",
+                offending_task_id=task_id,
+                original_action="resume",
+                original_prompt_head=prompt.split("\n", 1)[0][:80] if prompt else "",
+            )
+            return
+
+        # Case A: session 已结束
+        if task.status in {"completed", "failed"}:
+            if not case_a_enabled():
+                self._reject(
+                    reason="case_a_not_implemented",
+                    offending_task_id=task_id,
+                    original_action="resume",
+                    original_prompt_head=prompt.split("\n", 1)[0][:80] if prompt else "",
+                )
+                return
+            if self._executor is None:
+                self._reject(
+                    reason="executor_not_wired",
+                    offending_task_id=task_id,
+                    original_action="resume",
+                )
+                return
+            csid = task.session.claude_session_id if task.session else None
+            try:
+                new_run_id, new_pid = self._executor.spawn_resume(csid, prompt)
+            except ClaudeSessionNotFoundError:
+                self._mark_resume_failed(task_id, reason="resume_csid_lost", prev_csid=csid)
+                return
+            # 成功 spawn → 通过 ExecutionApplier.start_task 标记 (单一通路)
+            # Phase 1 后续 commit: 注入 ExecutionApplier 并调用 start_task
+            with self._board._lock:
+                task.status = "executing"
+                self._board._timeline.append_entry(
+                    data_type="task_resumed_caseA",
+                    by=self.name,
+                    task_id=task_id,
+                    data={"new_run_id": new_run_id, "new_pid": new_pid, "csid": csid},
+                )
+            return
+
+        # Case B: session 在跑 (executing) → ResumeInbox 注入
+        if task.status == "executing":
+            if self._resume_inbox is None:
+                # Phase 1 后续 commit: 注入实际 ResumeInbox 实例
+                # 当前 fallback: 仅 record_resume_pending + 落 timeline, 不实际 enqueue
+                with self._board._lock:
+                    self._board._timeline.append_entry(
+                        data_type="task_resume_pending_caseB",
+                        by=self.name,
+                        task_id=task_id,
+                        data={"prompt_head": prompt.split("\n", 1)[0][:80]},
+                    )
+                return
+            csid = task.session.claude_session_id if task.session else None
+            self._resume_inbox.enqueue(csid, task_id, prompt)
+            with self._board._lock:
+                self._board._timeline.append_entry(
+                    data_type="task_resume_pending_caseB",
+                    by=self.name,
+                    task_id=task_id,
+                    data={"prompt_head": prompt.split("\n", 1)[0][:80]},
+                )
+            return
+
+    def _mark_resume_failed(self, task_id: str, *, reason: str, prev_csid: str | None) -> None:
+        with self._board._lock:
+            task = self._board._find_task(task_id)
+            if task is None:
+                return
+            task.status = "resume_failed"  # type: ignore[assignment]
+            self._board._timeline.append_entry(
+                data_type=reason,  # resume_csid_lost
+                by=self.name,
+                task_id=task_id,
+                data={"prev_csid": prev_csid},
+            )

--- a/tests/server/test_taskboard_applier_invariants.py
+++ b/tests/server/test_taskboard_applier_invariants.py
@@ -1,0 +1,107 @@
+"""Phase 1 test_taskboard_applier_invariants.py — Ce Gap 2 新增 (T5.2 + T_B1.1/T_B1.2).
+
+T5.2 (post_archive_reject) — applier 公共不变量
+T_B1.1 (scheduled fast-path Msg 状态) — Ingestor.ingest_scheduled 行为
+T_B1.2 (Source default 完整性) — scheduled channel 字段约定
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from frago.server.services.taskboard.board import TaskBoard
+from frago.server.services.taskboard.ingestor import Ingestor
+from frago.server.services.taskboard.timeline import Timeline
+
+
+def _make_board(tmp_path):
+    timeline = Timeline(tmp_path / "timeline.jsonl")
+    return TaskBoard(timeline)
+
+
+def test_t_b1_1_scheduled_fast_path_msg_dispatched(tmp_path):
+    """T_B1.1 — scheduled trigger 经 ingest_scheduled 后, Msg 应进 dispatched 状态.
+
+    Phase 1 当前实现: append_msg(received) → append_task 后 msg.status → dispatched.
+    最终 board 中 msg.status == "dispatched" (不应停留在 awaiting_decision).
+    """
+    board = _make_board(tmp_path)
+    ing = Ingestor(board)
+    msg = ing.ingest_scheduled(
+        schedule_id="job_123",
+        prompt="定时任务摘要\n\n正文",
+        trigger_at=datetime(2026, 5, 12, 9, 0, 0, tzinfo=timezone.utc),
+        job_name="daily_report",
+    )
+    # msg 进 board 后, status 应为 dispatched (append_task 改的)
+    assert msg.status == "dispatched"
+    # board 内 thread 存在
+    threads = list(board._threads.values())
+    scheduled_threads = [t for t in threads if t.origin == "scheduled"]
+    assert len(scheduled_threads) == 1
+    assert scheduled_threads[0].subkind == "daily_report"
+
+
+def test_t_b1_2_source_default_completeness(tmp_path):
+    """T_B1.2 — scheduled msg.source 字段完整性 (Yi B1 决议 default 值)."""
+    board = _make_board(tmp_path)
+    ing = Ingestor(board)
+    trigger_at = datetime(2026, 5, 12, 9, 0, 0, tzinfo=timezone.utc)
+    msg = ing.ingest_scheduled(
+        schedule_id="job_xyz",
+        prompt="测试\n\n正文",
+        trigger_at=trigger_at,
+        job_name="test_job",
+    )
+    src = msg.source
+    assert src.channel == "scheduled"
+    assert src.sender_id == "__scheduler__"
+    assert src.parent_ref == "job_xyz"
+    assert src.received_at == trigger_at
+    assert src.text == "测试\n\n正文"
+    assert src.reply_context is None
+
+
+def test_t_b1_2_source_frozen_immutable(tmp_path):
+    """Phase 0 Source frozen=True 在 scheduled 路径也成立."""
+    from dataclasses import FrozenInstanceError
+
+    board = _make_board(tmp_path)
+    ing = Ingestor(board)
+    msg = ing.ingest_scheduled(
+        schedule_id="j", prompt="x\n\ny",
+        trigger_at=datetime.now(timezone.utc), job_name="j",
+    )
+    with pytest.raises(FrozenInstanceError):
+        msg.source.channel = "external"  # type: ignore[misc]
+
+
+def test_t5_2_post_archive_reject(tmp_path):
+    """T5.2 — thread 已 archived 后 append entry → applier reject.
+
+    Phase 1 范围: board.record_thread_archived 公有方法未实装 (留 Phase 2 vacuum).
+    本测试占位, Phase 2 vacuum 实施时补完整验证.
+    """
+    pytest.skip("T5.2 board.record_thread_archived + post_archive_append 检测留 Phase 2 vacuum")
+
+
+def test_scheduled_thread_not_merged(tmp_path):
+    """B1 决议: scheduled channel 不归并, 每次触发独立 thread."""
+    board = _make_board(tmp_path)
+    ing = Ingestor(board)
+    msg1 = ing.ingest_scheduled(
+        schedule_id="job_A", prompt="x\n\ny",
+        trigger_at=datetime(2026, 5, 12, 9, 0, 0, tzinfo=timezone.utc),
+        job_name="A",
+    )
+    msg2 = ing.ingest_scheduled(
+        schedule_id="job_A", prompt="x\n\ny",
+        trigger_at=datetime(2026, 5, 12, 10, 0, 0, tzinfo=timezone.utc),
+        job_name="A",
+    )
+    # 同 schedule_id 但不同 trigger_at 应产生不同 thread (不归并)
+    threads = [t for t in board._threads.values() if t.origin == "scheduled"]
+    assert len(threads) == 2
+    assert msg1.msg_id != msg2.msg_id

--- a/tests/server/test_taskboard_decision_applier.py
+++ b/tests/server/test_taskboard_decision_applier.py
@@ -1,0 +1,95 @@
+"""Phase 1 test_taskboard_decision_applier.py — T3.1~T3.4 (Ce specify 00:18:41)."""
+
+from __future__ import annotations
+
+import pytest
+
+from frago.server.services.taskboard.board import TaskBoard
+from frago.server.services.taskboard.decision_applier import (
+    DecisionApplier,
+    validate_prompt_format,
+)
+from frago.server.services.taskboard.timeline import Timeline
+
+
+def _make_board(tmp_path):
+    timeline = Timeline(tmp_path / "timeline.jsonl")
+    return TaskBoard(timeline)
+
+
+def test_t3_1_action_invalid_reject(tmp_path):
+    """T3.1 — action ∉ {run, reply, resume, dismiss} → reject(action_invalid)."""
+    board = _make_board(tmp_path)
+    da = DecisionApplier(board)
+    da.handle_pa_output([{"action": "delete", "msg_id": "m1", "prompt": "x\n\ny"}])
+    view = board.view_for_pa()
+    rejections = view["recent_rejections"]
+    assert len(rejections) == 1
+    assert rejections[0]["reason"] == "action_invalid"
+    assert rejections[0]["original_action"] == "delete"
+
+
+def test_t3_2_prompt_format_invalid_first_line_too_long(tmp_path):
+    """T3.2 子 case 1: 首行 >80 字 → reject."""
+    long_first = "x" * 100
+    board = _make_board(tmp_path)
+    da = DecisionApplier(board)
+    da.handle_pa_output([{"action": "run", "msg_id": "m1", "prompt": f"{long_first}\n\ny"}])
+    rejections = board.view_for_pa()["recent_rejections"]
+    assert len(rejections) == 1
+    assert rejections[0]["reason"] == "prompt_format_invalid"
+
+
+def test_t3_2_prompt_format_invalid_no_blank_line(tmp_path):
+    """T3.2 子 case 2: 缺空行分隔 → reject."""
+    board = _make_board(tmp_path)
+    da = DecisionApplier(board)
+    da.handle_pa_output([{"action": "run", "msg_id": "m1", "prompt": "summary\nbody-without-blank"}])
+    rejections = board.view_for_pa()["recent_rejections"]
+    assert any(r["reason"] == "prompt_format_invalid" for r in rejections)
+
+
+def test_t3_2_prompt_format_invalid_code_fence_in_first_line(tmp_path):
+    """T3.2 子 case 3: 首行含 ``` 围栏 → reject."""
+    board = _make_board(tmp_path)
+    da = DecisionApplier(board)
+    da.handle_pa_output([{"action": "run", "msg_id": "m1", "prompt": "summary ```\n\nbody"}])
+    rejections = board.view_for_pa()["recent_rejections"]
+    assert any(r["reason"] == "prompt_format_invalid" for r in rejections)
+
+
+def test_validate_prompt_format_valid(tmp_path):
+    """T3.2 valid case: 首行 ≤80 + 空行 + 正文 → None (合法)."""
+    assert validate_prompt_format("摘要\n\n正文") is None
+    assert validate_prompt_format("摘要 80 字以内\n\n正文 multi-line\nactually 多行") is None
+
+
+def test_t3_3_summary_first_line_not_truncate(tmp_path):
+    """T3.3 — original_prompt_head 取首行 (而非 prompt[:80] 硬截断)."""
+    board = _make_board(tmp_path)
+    da = DecisionApplier(board)
+    # 这条 prompt 首行 92 字 (>80), 会触发 prompt_format_invalid
+    prompt = "短摘要" + "x" * 100 + "\n\nbody"
+    da.handle_pa_output([{"action": "run", "msg_id": "m1", "prompt": prompt}])
+    rejections = board.view_for_pa()["recent_rejections"]
+    # original_prompt_head 是首行截断前 80 字, 不混入正文
+    assert "\n" not in rejections[0]["original_prompt_head"]
+
+
+def test_t3_4_recent_rejections_exposed_in_view_for_pa(tmp_path):
+    """T3.4 — recent_rejections 在 view_for_pa() 顶层暴露, PA 下轮可见."""
+    board = _make_board(tmp_path)
+    da = DecisionApplier(board)
+    # 触发 2 次拒绝
+    da.handle_pa_output([
+        {"action": "invalid1", "msg_id": "m1", "prompt": "x\n\ny"},
+        {"action": "invalid2", "msg_id": "m2", "prompt": "x\n\ny"},
+    ])
+    view = board.view_for_pa()
+    assert "recent_rejections" in view
+    assert len(view["recent_rejections"]) == 2
+    # 含 offending_msg_id / reason / original_action 字段
+    r0 = view["recent_rejections"][0]
+    assert "offending_msg_id" in r0
+    assert "reason" in r0
+    assert "original_action" in r0

--- a/tests/server/test_taskboard_resume_applier.py
+++ b/tests/server/test_taskboard_resume_applier.py
@@ -1,0 +1,171 @@
+"""Phase 1 test_taskboard_resume_applier.py — T9.1~T9.7a (Ce specify 00:18:41)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from frago.server.services.taskboard.board import TaskBoard
+from frago.server.services.taskboard.models import (
+    ClaudeSessionNotFoundError,
+    Intent,
+    Msg,
+    Source,
+    Task,
+    Thread,
+)
+from frago.server.services.taskboard.resume_applier import ResumeApplier
+from frago.server.services.taskboard.timeline import Timeline
+
+
+def _make_board_with_task(tmp_path, status="completed", csid="csid_x"):
+    """构造一个 board 含一个指定 status 的 task."""
+    timeline = Timeline(tmp_path / "timeline.jsonl")
+    board = TaskBoard(timeline)
+    # 直接 manual 构造对象 (绕过 fold)
+    thread = Thread(
+        thread_id="T1",
+        status="active",
+        origin="external",
+        subkind="feishu",
+        root_summary="test",
+        created_at=datetime.now(timezone.utc),
+        last_active_at=datetime.now(timezone.utc),
+    )
+    src = Source(
+        channel="feishu",
+        text="hi",
+        sender_id="u1",
+        parent_ref=None,
+        received_at=datetime.now(timezone.utc),
+        reply_context=None,
+    )
+    msg = Msg(msg_id="feishu:M1", status="dispatched", source=src)
+    task = Task(
+        task_id="TK1",
+        status=status,
+        type="run",
+        intent=Intent(prompt="摘要\n\n正文"),
+    )
+    msg.tasks.append(task)
+    thread.msgs.append(msg)
+    board._threads["T1"] = thread
+    return board, task
+
+
+def test_t9_1_case_a_not_implemented_reject(tmp_path, monkeypatch):
+    """T9.1 — Case A 未启用期, resume completed/failed task → reject(case_a_not_implemented)."""
+    monkeypatch.delenv("FRAGO_CASE_A_ENABLED", raising=False)
+    board, task = _make_board_with_task(tmp_path, status="completed")
+    ra = ResumeApplier(board)
+    ra.route_resume("TK1", "新指令\n\n继续做 X")
+    rejections = board.view_for_pa()["recent_rejections"]
+    assert any(r["reason"] == "case_a_not_implemented" for r in rejections)
+    # task 状态不变
+    assert task.status == "completed"
+
+
+def test_t9_2_rejection_visible_in_view_for_pa(tmp_path, monkeypatch):
+    """T9.2 — 拒绝可见性: view_for_pa.recent_rejections[0].reason == case_a_not_implemented."""
+    monkeypatch.delenv("FRAGO_CASE_A_ENABLED", raising=False)
+    board, task = _make_board_with_task(tmp_path, status="failed")
+    ra = ResumeApplier(board)
+    ra.route_resume("TK1", "重试\n\nx")
+    view = board.view_for_pa()
+    assert view["recent_rejections"][0]["reason"] == "case_a_not_implemented"
+    assert view["recent_rejections"][0]["offending_task_id"] == "TK1"
+
+
+def test_t9_3_case_a_happy_path(tmp_path, monkeypatch):
+    """T9.3 — Case A enabled + valid csid → spawn_resume 调用, task → executing."""
+    monkeypatch.setenv("FRAGO_CASE_A_ENABLED", "1")
+    board, task = _make_board_with_task(tmp_path, status="completed", csid="csid_x")
+    # 给 task 一个 session 才能拿到 csid
+    from frago.server.services.taskboard.models import Session
+    task.session = Session(
+        run_id="R1", claude_session_id="csid_x", pid=123,
+        started_at=datetime.now(timezone.utc), ended_at=datetime.now(timezone.utc),
+    )
+
+    class FakeExecutor:
+        def spawn_resume(self, csid, prompt):
+            assert csid == "csid_x"
+            return ("R2", 456)
+
+    ra = ResumeApplier(board, executor=FakeExecutor())
+    ra.route_resume("TK1", "继续\n\n追加 X")
+    assert task.status == "executing"
+
+
+def test_t9_4_csid_lost_resume_failed(tmp_path, monkeypatch):
+    """T9.4 — Case A spawn_resume 抛 ClaudeSessionNotFoundError → task.status=resume_failed."""
+    monkeypatch.setenv("FRAGO_CASE_A_ENABLED", "1")
+    board, task = _make_board_with_task(tmp_path, status="completed")
+    from frago.server.services.taskboard.models import Session
+    task.session = Session(
+        run_id="R1", claude_session_id="csid_expired", pid=123,
+        started_at=datetime.now(timezone.utc), ended_at=datetime.now(timezone.utc),
+    )
+
+    class FakeExecutor:
+        def spawn_resume(self, csid, prompt):
+            raise ClaudeSessionNotFoundError(f"session {csid} not found")
+
+    ra = ResumeApplier(board, executor=FakeExecutor())
+    ra.route_resume("TK1", "重试\n\nx")
+    assert task.status == "resume_failed"
+
+
+def test_t9_5_resume_failed_in_must_act_set(tmp_path):
+    """T9.5 — resume_failed 是新终态, 进 §7 必须做集合. 当前测试 task.status 字段值合法."""
+    from frago.server.services.taskboard.models import Task as TaskModel
+    # spec freeze §2 增 resume_failed 终态
+    valid_statuses = TaskModel.__annotations__.get("status")
+    # Literal 实际不可直接 introspect, 用实例化验证字段接受
+    t = TaskModel(
+        task_id="TX",
+        status="resume_failed",  # 接受新值
+        type="run",
+        intent=Intent(prompt="x\n\ny"),
+    )
+    assert t.status == "resume_failed"
+
+
+def test_t9_6_history_via_timeline_search(tmp_path):
+    """T9.6 — 历史 run 轨迹查询走 timeline (task_started entries).
+
+    Phase 1 范围: ExecutionApplier.start_task 写 task_started entry, 多次 start (resume) 累积 N 条.
+    本测试验证 timeline 含 ≥1 task_started entry, 完整 N 次 timeline scan 是 CLI 职责留 Phase 2.
+    """
+    pytest.skip("T9.6 完整覆盖留 Phase 2 (frago tasks task --history CLI 集成测试)")
+
+
+def test_t9_7a_task_history_structure(tmp_path):
+    """T9.7a (Ce Gap 5 拆 a/b) — frago tasks task --history CLI 返回结构正确.
+
+    Phase 1 范围: 不约束耗时, 仅校字段集 {run_id, csid, started_at, ended_at, error, summary}.
+    CLI 实装留 Phase 1 后续 commit. 当前测试占位。
+    """
+    pytest.skip("T9.7a CLI 实装留 Phase 1 后续 commit (task_commands.py --history flag)")
+
+
+def test_resume_executing_task_case_b_pending(tmp_path):
+    """补充 case: executing task → Case B (ResumeInbox + record_resume_pending).
+
+    Phase 1 当前 ResumeApplier 未注入 ResumeInbox 实例 → fallback 落 timeline entry.
+    """
+    board, task = _make_board_with_task(tmp_path, status="executing")
+    ra = ResumeApplier(board, resume_inbox=None)
+    ra.route_resume("TK1", "插队\n\n先做 X")
+    # task 状态保持 executing, 仅落 timeline
+    assert task.status == "executing"
+
+
+def test_resume_illegal_state_reject(tmp_path):
+    """task.status ∈ {queued, replied, resume_failed} → reject(resume_illegal_state)."""
+    board, task = _make_board_with_task(tmp_path, status="queued")
+    ra = ResumeApplier(board)
+    ra.route_resume("TK1", "x\n\ny")
+    rejections = board.view_for_pa()["recent_rejections"]
+    assert any(r["reason"] == "resume_illegal_state" for r in rejections)


### PR DESCRIPTION
## Summary
- Applier 接口 4 类: BaseApplier / DecisionApplier / ExecutionApplier / ResumeApplier
- 4 action 词汇 (run/reply/resume/dismiss) + prompt 格式契约 (首行 ≤80 + 空行 + 正文)
- ResumeApplier Case A stage-gate (FRAGO_CASE_A_ENABLED env var) + CSID 失效 → resume_failed (新终态)
- Ingestor.ingest_scheduled (Gap 3a): scheduled fast-path, thread 不归并
- pa_validators: 加 dismiss / validate_prompt_format() / VALID_MSG_ACTIONS=4 (严格)

Part A 仅建接口骨架, 不动主 PA 决策路径 (避免破坏 server). 重复响应根因回归测试推 part B.

## Test plan
- [x] uv run pytest tests/server/test_taskboard_*.py → 32 passed + 3 skipped + 0 failed (commit 8daaf626)
  - Phase 0 14 用例 regression-free
  - Phase 1 part A 新增 18 用例: 15 pass + 3 skip (T9.6/T9.7a 推 part B; T5.2 推 Phase 2 vacuum)
- [x] Ce cross-verify 32/3/0 + T9.5 实测 pass (Kai 自报笔误已矫正) (jsonl #63)
- [x] Yi scope approve part A 拆分 + 硬性 dep "part B 紧跟 part A merge, 禁跳 Phase 2" (jsonl #62 + #64)

## Phase 1 part B (紧跟本 PR merge, 不允许跳 Phase 2)
primary_agent_service._handle_pa_output 改调 DecisionApplier + executor.spawn_resume 实装 + resume_inbox 入口改 ResumeApplier.route_resume + scheduler 摘 message_cache + **删** ingestion/store.py + models.py + thread_service.py + 同步改 reflection_tick / task_lifecycle / task_service / task_commands / pa_prompts / board.py 等. 验收线: 同一条飞书消息触发 10 次 → PA 输出恰好 1 个 decision (重复响应根因回归).

🤖 Generated with [Claude Code](https://claude.com/claude-code)