### PR TITLE
feat(taskboard): finish spec gaps (GAP-1..6) — _message_cache strip + cli/tasks + fold.py + perf test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ tests/*
 tests/server/*
 !tests/server/test_taskboard_*.py
 !tests/server/test_repeat_response_production_path.py
+!tests/server/test_timeline_query_perf.py
 tests/results/
 tests/*.log
 coverage/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,9 @@ addopts = [
     "--cov-report=term-missing",
     "--cov-report=html",
 ]
+markers = [
+    "perf: marks performance-bounded tests (e.g. T9.7b timeline scan ≤5s). Run via 'pytest -m perf' to isolate; exclude in fast CI via '-m \"not perf\"'.",
+]
 
 [tool.ruff]
 target-version = "py313"

--- a/src/frago/cli/task_commands.py
+++ b/src/frago/cli/task_commands.py
@@ -134,3 +134,246 @@ def task_mark(task_id, status, reason, error, result_summary):
         "reason": reason,
         "note": "task_state entry emitted — safe against rebuild_status_cache reversion",
     }, ensure_ascii=False))
+
+
+# ---------------------------------------------------------------------------
+# Phase finish (spec line 11): list / awaiting / active / stats subcommands
+# ---------------------------------------------------------------------------
+# These commands read ~/.frago/timeline/timeline.jsonl via TaskBoard.fold so
+# they work offline (server not required). Agents use them for ground-truth
+# board state inspection without going through the server's HTTP API.
+
+
+def _fold_board_offline():
+    """Boot a fresh TaskBoard by folding ~/.frago/timeline/timeline.jsonl.
+
+    Returns (board, timeline_path). Returns (None, path) when timeline is
+    absent — callers should treat that as an empty board.
+    """
+    from pathlib import Path as _Path
+
+    from frago.server.services.taskboard.board import TaskBoard
+
+    timeline_path = _Path.home() / ".frago" / "timeline" / "timeline.jsonl"
+    if not timeline_path.exists():
+        return None, timeline_path
+    return TaskBoard.fold(timeline_path), timeline_path
+
+
+@task_group.command(name="list", cls=AgentFriendlyCommand)
+@click.option("--json", "as_json", is_flag=True, default=False,
+              help="Emit raw JSON (default: human-readable)")
+def task_list(as_json: bool):
+    """List the current board snapshot — threads, msgs, tasks.
+
+    Reads ~/.frago/timeline/timeline.jsonl by folding offline (no server
+    required). Output groups msgs under their thread and tasks under each msg.
+
+    Examples:
+      frago task list
+      frago task list --json | jq '.threads[] | select(.status=="active")'
+    """
+    board, timeline_path = _fold_board_offline()
+    if board is None:
+        payload = {
+            "threads": [],
+            "note": f"timeline.jsonl missing at {timeline_path}",
+        }
+        click.echo(json.dumps(payload, ensure_ascii=False, indent=2))
+        return
+
+    view = board.view_for_pa()
+    payload = {
+        "thread_count": len(view.get("threads", [])),
+        "threads": view.get("threads", []),
+    }
+
+    if as_json:
+        click.echo(json.dumps(payload, ensure_ascii=False, indent=2))
+        return
+
+    threads = view.get("threads", [])
+    if not threads:
+        click.echo("(no threads on board)")
+        return
+    for t in threads:
+        click.echo(
+            f"thread {t['id']} [{t.get('status', '?')}] subkind={t.get('subkind', '?')} "
+            f"msgs={len(t.get('msgs', []))}"
+        )
+        for m in t.get("msgs", []):
+            click.echo(
+                f"  msg {m['id']} [{m.get('status', '?')}] "
+                f"tasks={len(m.get('tasks', []))}"
+            )
+            for tk in m.get("tasks", []):
+                click.echo(
+                    f"    task {tk['id']} type={tk.get('type', '?')} "
+                    f"status={tk.get('status', '?')}"
+                )
+
+
+@task_group.command(name="awaiting", cls=AgentFriendlyCommand)
+@click.option("--json", "as_json", is_flag=True, default=False)
+def task_awaiting(as_json: bool):
+    """List Msgs in status=awaiting_decision (PA has not decided yet).
+
+    Helps diagnose PA stalled / queue backlog.
+
+    Examples:
+      frago task awaiting
+      frago task awaiting --json
+    """
+    board, timeline_path = _fold_board_offline()
+    rows: list[dict] = []
+    if board is not None:
+        for t in board.view_for_pa().get("threads", []):
+            for m in t.get("msgs", []):
+                if m.get("status") != "awaiting_decision":
+                    continue
+                rows.append({
+                    "thread_id": t.get("id"),
+                    "subkind": t.get("subkind"),
+                    "msg_id": m.get("id"),
+                    "channel": m.get("channel"),
+                    "sender_id": m.get("sender_id"),
+                })
+
+    payload = {"count": len(rows), "awaiting": rows}
+    if as_json:
+        click.echo(json.dumps(payload, ensure_ascii=False, indent=2))
+        return
+    if not rows:
+        click.echo("(no msgs awaiting PA decision)")
+        return
+    for r in rows:
+        click.echo(
+            f"awaiting {r['msg_id']} thread={r['thread_id']} channel={r.get('channel', '?')} sender={r.get('sender_id', '?')}"
+        )
+
+
+@task_group.command(name="active", cls=AgentFriendlyCommand)
+@click.option("--json", "as_json", is_flag=True, default=False)
+def task_active(as_json: bool):
+    """List Tasks in status in {queued, executing}.
+
+    Helps diagnose sub-agent stalled / executor backlog.
+
+    Examples:
+      frago task active
+      frago task active --json
+    """
+    board, _ = _fold_board_offline()
+    rows: list[dict] = []
+    active_set = {"queued", "executing"}
+    if board is not None:
+        for t in board.view_for_pa().get("threads", []):
+            for m in t.get("msgs", []):
+                for tk in m.get("tasks", []):
+                    if tk.get("status") not in active_set:
+                        continue
+                    rows.append({
+                        "thread_id": t.get("id"),
+                        "msg_id": m.get("id"),
+                        "task_id": tk.get("id"),
+                        "type": tk.get("type"),
+                        "status": tk.get("status"),
+                    })
+
+    payload = {"count": len(rows), "active": rows}
+    if as_json:
+        click.echo(json.dumps(payload, ensure_ascii=False, indent=2))
+        return
+    if not rows:
+        click.echo("(no active tasks: queued or executing)")
+        return
+    for r in rows:
+        click.echo(
+            f"active {r['task_id']} type={r.get('type', '?')} status={r.get('status', '?')} "
+            f"msg={r.get('msg_id', '?')}"
+        )
+
+
+@task_group.command(name="stats", cls=AgentFriendlyCommand)
+@click.option("--json", "as_json", is_flag=True, default=False)
+def task_stats(as_json: bool):
+    """Long-running health stats for the board.
+
+    Reports:
+      timeline_bytes       — current ~/.frago/timeline/timeline.jsonl size
+      threads_count        — total threads on board (active + dormant + closed + archived)
+      active_msgs          — msgs in awaiting_decision / dispatched
+      queued_tasks         — tasks in queued
+      executing_tasks      — tasks in executing
+      archived_threads     — last vacuum cycle's archived_threads_count (from
+                             most recent startup_fold_completed entry)
+      last_fold_duration_ms — most recent boot fold duration
+
+    Examples:
+      frago task stats
+      frago task stats --json | jq '.timeline_bytes'
+    """
+    from pathlib import Path as _Path
+
+    timeline_path = _Path.home() / ".frago" / "timeline" / "timeline.jsonl"
+    timeline_bytes = timeline_path.stat().st_size if timeline_path.exists() else 0
+
+    board, _ = _fold_board_offline()
+    threads_count = 0
+    active_msgs = 0
+    queued_tasks = 0
+    executing_tasks = 0
+    if board is not None:
+        view = board.view_for_pa()
+        threads_count = len(view.get("threads", []))
+        for t in view.get("threads", []):
+            for m in t.get("msgs", []):
+                if m.get("status") in {"awaiting_decision", "dispatched"}:
+                    active_msgs += 1
+                for tk in m.get("tasks", []):
+                    s = tk.get("status")
+                    if s == "queued":
+                        queued_tasks += 1
+                    elif s == "executing":
+                        executing_tasks += 1
+
+    archived_threads = 0
+    last_fold_duration_ms: int | None = None
+    if timeline_path.exists():
+        # walk from end backwards for the latest startup_fold_completed
+        try:
+            for line in reversed(timeline_path.read_text(encoding="utf-8").splitlines()):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if entry.get("data_type") == "startup_fold_completed":
+                    data = entry.get("data") or {}
+                    archived_threads = int(data.get("archived_threads_count", 0))
+                    last_fold_duration_ms = data.get("fold_duration_ms")
+                    break
+        except OSError:
+            pass
+
+    payload = {
+        "timeline_bytes": timeline_bytes,
+        "threads_count": threads_count,
+        "active_msgs": active_msgs,
+        "queued_tasks": queued_tasks,
+        "executing_tasks": executing_tasks,
+        "archived_threads": archived_threads,
+        "last_fold_duration_ms": last_fold_duration_ms,
+    }
+
+    if as_json:
+        click.echo(json.dumps(payload, ensure_ascii=False, indent=2))
+        return
+    click.echo(
+        f"timeline_bytes={payload['timeline_bytes']} threads={payload['threads_count']} "
+        f"active_msgs={payload['active_msgs']} queued={payload['queued_tasks']} "
+        f"executing={payload['executing_tasks']} archived={payload['archived_threads']} "
+        f"last_fold_ms={payload['last_fold_duration_ms']}"
+    )

--- a/src/frago/server/services/ingestion/scheduler.py
+++ b/src/frago/server/services/ingestion/scheduler.py
@@ -11,11 +11,12 @@ The scheduler's job is:
 
 Phase 1 part B-2a (root-cause fix): the legacy per-channel disk dedup file is
 removed. TaskBoard's append_msg dedup (same msg_id → duplicate_msg_ingest
-timeline entry, no second task) is now the only dedup gate. Stale callers of
-``cache_message`` / ``get_cached_message`` / ``remove_cached_message`` continue
-to compile via in-memory shims that mirror the latest ingest payload long
-enough for primary_agent_service legacy reply path (those callers move to
-TaskBoard in B-2b).
+timeline entry, no second task) is now the only dedup gate.
+
+Phase finish (post-#74): the in-memory ``_message_cache`` shim is also removed
+along with ``cache_message`` / ``get_cached_message`` / ``remove_cached_message``.
+Callers that previously read the shim now read board.view_for_pa directly
+(msg.reply_context, msg.channel are exposed there).
 """
 
 import asyncio
@@ -24,7 +25,7 @@ import json
 import logging
 import os
 import shutil
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -32,24 +33,6 @@ from frago.compat import get_windows_subprocess_kwargs
 from frago.server.services.taskboard.legacy_store import TaskStore
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass
-class CachedMessage:
-    """In-memory mirror of the most recent ingest payload per (channel, msg_id).
-
-    Kept as a transient shim during B-2a so legacy callers in
-    primary_agent_service can still resolve prompt/reply_context until B-2b
-    rewrites them to read TaskBoard directly. No longer persisted to disk —
-    the durable source is ``~/.frago/timeline/timeline.jsonl``.
-    """
-
-    channel: str
-    msg_id: str
-    prompt: str
-    reply_context: dict[str, Any] = field(default_factory=dict)
-    received_at: datetime = field(default_factory=datetime.now)
-    thread_id: str | None = None
 
 
 @dataclass
@@ -84,10 +67,6 @@ class IngestionScheduler:
         # Shared runner — avoids recreating RecipeRegistry + ExecutionStore per poll
         from frago.recipes.runner import RecipeRunner
         self._runner = RecipeRunner()
-        # In-memory shim (B-2a transitional): mirror most recent payload per key.
-        # Empty on boot — no longer rebuilt from disk. Cleared after each PA decision
-        # cycle by primary_agent_service.remove_cached_message.
-        self._message_cache: dict[str, CachedMessage] = {}
 
     def set_pa_enqueue(self, enqueue_fn: object) -> None:
         """Register the PA message queue enqueue function.
@@ -96,29 +75,6 @@ class IngestionScheduler:
         can deliver messages to the PA queue without a circular import.
         """
         self._pa_enqueue = enqueue_fn
-
-    def cache_message(self, msg: CachedMessage) -> None:
-        """Insert a message into the transient shim. Used by SchedulerService
-        for scheduled_task delivery (legacy path until B-2b). B-2a no longer
-        persists to disk.
-        """
-        key = f"{msg.channel}:{msg.msg_id}"
-        self._message_cache[key] = msg
-        logger.debug("Cached message %s (in-memory shim)", key)
-
-    def get_cached_message(self, channel: str, msg_id: str) -> CachedMessage | None:
-        """Retrieve the in-memory shim entry. Returns None after restart or
-        after ``remove_cached_message`` cleared the key — callers in
-        primary_agent_service handle the miss by skipping task creation.
-        """
-        return self._message_cache.get(f"{channel}:{msg_id}")
-
-    def remove_cached_message(self, channel: str, msg_id: str) -> None:
-        """Drop a processed message from the in-memory shim."""
-        key = f"{channel}:{msg_id}"
-        if key in self._message_cache:
-            del self._message_cache[key]
-            logger.debug("Removed cached message %s", key)
 
     async def start(self) -> None:
         if self._channel_tasks:
@@ -292,19 +248,6 @@ class IngestionScheduler:
             thread_id=classify_result.thread_id,
         )
 
-        # B-2a transitional shim: mirror payload in-memory so
-        # primary_agent_service legacy paths (reply enrichment, scheduled task
-        # cache lookup) keep working. B-2b will drop these readers and we can
-        # remove the shim. No disk persistence.
-        cached = CachedMessage(
-            channel=ch.name,
-            msg_id=msg_id,
-            prompt=msg["prompt"],
-            reply_context=reply_ctx,
-            thread_id=classify_result.thread_id,
-        )
-        self._message_cache[f"{ch.name}:{msg_id}"] = cached
-
         trace_entry(
             origin="external",
             subkind=ch.name,
@@ -333,7 +276,7 @@ class IngestionScheduler:
                     "prompt": msg["prompt"],
                     "reply_context": msg.get("reply_context", {}),
                     "thread_id": classify_result.thread_id,
-                    "received_at": cached.received_at.strftime("%Y-%m-%d %H:%M:%S"),
+                    "received_at": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
                 })
                 logger.info(
                     "Message %s enqueued to PA (thread=%s, layer=%s)",

--- a/src/frago/server/services/primary_agent_service.py
+++ b/src/frago/server/services/primary_agent_service.py
@@ -316,45 +316,10 @@ class PrimaryAgentService:
         self._rotation_count += 1
         self._consecutive_json_failures = 0
 
-        orphaned = await self._reconcile_orphaned_messages()
-        if orphaned:
-            logger.info("Rotation: re-enqueued %d orphaned message(s)", orphaned)
-
-    async def _reconcile_orphaned_messages(self) -> int:
-        """Phase 3: scan message_cache for messages without a board.msg entry, re-enqueue.
-
-        Reads board.view_for_pa() to determine which channel:msg_id pairs the
-        board already knows about; cached messages absent from board are orphans
-        from a mid-rotation chain break and get re-enqueued for PA decision.
-        """
-        if not self._scheduler:
-            return 0
-
-        board = get_board()
-        view = board.view_for_pa()
-        seen_board_msg_ids: set[str] = {
-            m["id"] for t in view.get("threads", []) for m in t.get("msgs", [])
-        }
-        orphaned = 0
-
-        for _key, cached in list(self._scheduler._message_cache.items()):
-            board_msg_id = f"{cached.channel}:{cached.msg_id}"
-            if board_msg_id in seen_board_msg_ids:
-                continue
-            await self.enqueue_message({
-                "type": "user_message",
-                "msg_id": cached.msg_id,
-                "channel": cached.channel,
-                "channel_message_id": cached.msg_id,
-                "prompt": cached.prompt,
-                "reply_context": cached.reply_context,
-                "_recovered": True,
-                "received_at": cached.received_at.strftime("%Y-%m-%d %H:%M:%S"),
-            })
-            orphaned += 1
-            logger.info("Orphaned message re-enqueued: %s:%s", cached.channel, cached.msg_id)
-
-        return orphaned
+        # Phase finish: orphan reconciliation removed alongside ingestion._message_cache.
+        # Ingestor.ingest_external/ingest_scheduled writes board synchronously, so every
+        # ingested message is on board immediately. There is no "cached but not yet on
+        # board" intermediate state to reconcile after rotation.
 
     def _build_bootstrap_prompt(self, create_reason: str | None = None) -> tuple[str, str]:
         """Build bootstrap context (board view + conversation history + knowledge)."""
@@ -404,33 +369,25 @@ class PrimaryAgentService:
             logger.warning("Failed to send online notification", exc_info=True)
 
     def _lookup_recent_reply_context(self, channel: str) -> dict | None:
-        """Phase 3: look up the most recent reply_context for ``channel`` from
-        cached messages. board view itself does not expose reply_context yet
-        (B-2d will widen view_for_pa); we ask the ingestion scheduler's cache
-        which holds the live message metadata produced by the channel pollers.
+        """Look up the most recent reply_context for ``channel`` from board.
+
+        Phase finish: view_for_pa now exposes msg.reply_context directly,
+        so this reads board only — no scheduler cache lookup.
         """
-        if not self._scheduler:
-            return None
         try:
-            board = get_board()
-            view = board.view_for_pa()
-            # Find latest msg on this channel (subkind) from board
-            latest_msg_id = None
+            view = get_board().view_for_pa()
+            latest_ctx: dict | None = None
             for t in view.get("threads", []):
                 if t.get("subkind") != channel:
                     continue
                 for m in t.get("msgs", []):
-                    mid = m.get("id", "")
-                    if mid.startswith(f"{channel}:"):
-                        latest_msg_id = mid.split(":", 1)[1]
-            if not latest_msg_id:
-                return None
-            cached = self._scheduler.get_cached_message(channel, latest_msg_id)
-            if cached and getattr(cached, "reply_context", None):
-                return cached.reply_context
+                    ctx = m.get("reply_context")
+                    if ctx:
+                        latest_ctx = ctx
+            return latest_ctx
         except Exception:
             logger.debug("reply_context board lookup failed", exc_info=True)
-        return None
+            return None
 
     # -- PA event broadcast --
 
@@ -660,17 +617,9 @@ class PrimaryAgentService:
                     run_count=msg.get("run_count", 0),
                     fired_at=msg.get("triggered_at") or "unknown",
                 ))
-                if self._scheduler and msg.get("msg_id"):
-                    from frago.server.services.ingestion.scheduler import CachedMessage
-                    cache_reply_ctx = dict(msg.get("reply_context") or {})
-                    cache_reply_ctx["schedule_id"] = msg.get("schedule_id", "")
-                    cache_reply_ctx["schedule_name"] = msg.get("schedule_name", "")
-                    self._scheduler.cache_message(CachedMessage(
-                        channel=msg_channel,
-                        msg_id=msg["msg_id"],
-                        prompt=msg.get("prompt", ""),
-                        reply_context=cache_reply_ctx,
-                    ))
+                # Phase finish: scheduled_task reply_context is now carried inline on
+                # board.Source (ingest_scheduled writes it through Ingestor) and on the
+                # queue dict above. No separate cache_message shim needed.
                 if msg.get("msg_id") and msg.get("schedule_id"):
                     self._schedule_msg_map[msg["msg_id"]] = msg["schedule_id"]
 
@@ -1050,14 +999,7 @@ class PrimaryAgentService:
             except Exception:
                 logger.exception("Failed to execute PA decision: %s", d)
 
-        # Deferred cache cleanup.
-        if self._scheduler:
-            seen_msg_ids: set[tuple[str, str]] = set()
-            for d in decisions:
-                if isinstance(d, dict) and d.get("msg_id"):
-                    seen_msg_ids.add((d.get("channel", ""), d["msg_id"]))
-            for channel_key, mid in seen_msg_ids:
-                self._scheduler.remove_cached_message(channel_key, mid)
+        # Phase finish: deferred cache cleanup removed alongside _message_cache shim.
 
         # Write back schedule results.
         if self._scheduler_service:
@@ -1333,10 +1275,23 @@ class PrimaryAgentService:
         reply_channel = decision.get("channel")
         reply_context: dict[str, Any] = {}
         msg_id = decision.get("msg_id", "")
-        if self._scheduler and msg_id:
-            cached = self._scheduler.get_cached_message(reply_channel or "", msg_id)
-            if cached and cached.reply_context:
-                reply_context = dict(cached.reply_context)
+        # Phase finish: reply_context read from board (view_for_pa exposes it).
+        if msg_id and reply_channel:
+            board_msg_id = f"{reply_channel}:{msg_id}"
+            try:
+                view = get_board().view_for_pa()
+                for t in view.get("threads", []):
+                    for m in t.get("msgs", []):
+                        if m.get("id") == board_msg_id:
+                            ctx = m.get("reply_context")
+                            if ctx:
+                                reply_context = dict(ctx)
+                            break
+            except Exception:
+                logger.debug(
+                    "schedule reply_context board lookup failed for %s",
+                    board_msg_id, exc_info=True,
+                )
 
         try:
             schedule = self._scheduler_service.add_schedule(

--- a/src/frago/server/services/taskboard/board.py
+++ b/src/frago/server/services/taskboard/board.py
@@ -749,6 +749,12 @@ class TaskBoard:
                             {
                                 "id": m.msg_id,
                                 "status": m.status,
+                                "channel": m.source.channel,
+                                "sender_id": m.source.sender_id,
+                                "reply_context": (
+                                    dict(m.source.reply_context)
+                                    if m.source.reply_context else None
+                                ),
                                 "tasks": [
                                     {"id": tk.task_id, "type": tk.type, "status": tk.status}
                                     for tk in m.tasks

--- a/src/frago/server/services/taskboard/board.py
+++ b/src/frago/server/services/taskboard/board.py
@@ -59,41 +59,22 @@ class TaskBoard:
         self.entries_read = 0
         self.entries_skipped = 0
 
-    # ── fold (两遍算法) ──────────────────────────────────────────────
+    # ── fold (两遍算法; 实现迁到 taskboard.fold 模块) ───────────────
 
     @classmethod
     def fold(cls, timeline_path: Path) -> TaskBoard:
-        """从 timeline.jsonl 重建内存投影。
+        """从 timeline.jsonl 重建内存投影 (thin wrapper around fold.fold).
 
-        两遍算法 (T5.1):
-        - 第一遍: 扫全文件收 archived_thread_ids set (data_type=='thread_archived')
-        - 第二遍: 读 entries 跳过该 set 内 thread_id 的全部 entries
+        Two-pass algorithm (T5.1):
+        - First pass: collect ``archived_thread_ids`` (data_type=='thread_archived')
+        - Second pass: replay entries, skip those whose thread_id is in the set
+
+        Phase finish: 算法主体迁入 ``frago.server.services.taskboard.fold``;
+        本方法保留为 backward-compat 入口, 行为不变.
         """
-        timeline = Timeline(timeline_path)
-        board = cls(timeline)
+        from frago.server.services.taskboard.fold import fold as _fold
 
-        # 第一遍
-        archived_thread_ids: set[str] = set()
-        for entry in timeline.iter_entries():
-            if entry.get("data_type") == "thread_archived":
-                tid = entry.get("thread_id")
-                if tid:
-                    archived_thread_ids.add(tid)
-
-        # 第二遍
-        entries_read = 0
-        entries_skipped = 0
-        for entry in timeline.iter_entries():
-            entries_read += 1
-            tid = entry.get("thread_id")
-            if tid in archived_thread_ids:
-                entries_skipped += 1
-                continue
-            board._apply_entry(entry)
-
-        board.entries_read = entries_read
-        board.entries_skipped = entries_skipped
-        return board
+        return _fold(timeline_path)
 
     def _apply_entry(self, entry: dict) -> None:
         """根据 data_type 把 timeline entry 转化为内存对象变更。

--- a/src/frago/server/services/taskboard/fold.py
+++ b/src/frago/server/services/taskboard/fold.py
@@ -1,0 +1,70 @@
+"""Two-pass fold of timeline.jsonl → in-memory TaskBoard projection.
+
+Spec ref: 20260512-msg-task-board-redesign §Phase 0 / T5.1.
+
+Algorithm:
+  1. First pass: scan all entries collect ``archived_thread_ids`` set from
+     ``data_type == 'thread_archived'`` markers.
+  2. Second pass: read entries, skip any whose ``thread_id`` is in the
+     archived set, replay the rest via ``board._apply_entry``.
+
+Lives in its own module (Phase finish — was inline in board.py prior) so the
+algorithm is independently testable and the dependency direction is
+``board → fold``, not the other way around.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from frago.server.services.taskboard.timeline import Timeline
+
+if TYPE_CHECKING:
+    from frago.server.services.taskboard.board import TaskBoard
+
+
+def fold_into_board(board: TaskBoard, timeline_path: Path) -> tuple[int, int]:
+    """Populate ``board`` by replaying entries from ``timeline_path``.
+
+    Returns ``(entries_read, entries_skipped)``. ``board`` mutation is in-place.
+    Caller is responsible for storing the counts (typically on the board).
+    """
+    timeline = Timeline(timeline_path)
+
+    # First pass: collect archived thread ids
+    archived_thread_ids: set[str] = set()
+    for entry in timeline.iter_entries():
+        if entry.get("data_type") == "thread_archived":
+            tid = entry.get("thread_id")
+            if tid:
+                archived_thread_ids.add(tid)
+
+    # Second pass: replay non-archived entries
+    entries_read = 0
+    entries_skipped = 0
+    for entry in timeline.iter_entries():
+        entries_read += 1
+        tid = entry.get("thread_id")
+        if tid in archived_thread_ids:
+            entries_skipped += 1
+            continue
+        board._apply_entry(entry)
+
+    return entries_read, entries_skipped
+
+
+def fold(timeline_path: Path) -> TaskBoard:
+    """Convenience wrapper: build a fresh board and fold ``timeline_path`` into it.
+
+    Equivalent to ``TaskBoard.fold(timeline_path)`` — kept as a top-level
+    function so the algorithm can be invoked without holding the TaskBoard
+    class import path.
+    """
+    from frago.server.services.taskboard.board import TaskBoard
+
+    board = TaskBoard(Timeline(timeline_path))
+    entries_read, entries_skipped = fold_into_board(board, timeline_path)
+    board.entries_read = entries_read
+    board.entries_skipped = entries_skipped
+    return board

--- a/tests/server/test_timeline_query_perf.py
+++ b/tests/server/test_timeline_query_perf.py
@@ -1,0 +1,146 @@
+"""T9.7b: perf assertion for frago task history on a 10000-entry timeline.
+
+spec ref: 20260512-msg-task-board-redesign §AC T9.7b — task history query
+against a 10000-entry ~/.frago/timeline/timeline.jsonl finishes in ≤ 5 s.
+
+Fixture generates a real JSONL on disk with mixed data types (task_appended /
+task_started / task_finished / task_resumed_caseA + duplicate_msg_ingest noise)
+across many task_ids; one target task_id has a full run history (init + 3
+resumes) so the test can both measure scan time and verify correctness of the
+returned entries.
+
+The test is marked ``@pytest.mark.perf`` so it can be excluded from default
+fast suites via ``pytest -m 'not perf'`` if CI ever needs to gate on it.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from frago.cli.task_commands import task_history
+
+TARGET_TASK_ID = "T_PERF_TARGET"
+TOTAL_ENTRIES = 10_000
+TARGET_HISTORY_ROUNDS = 4  # init + 3 resumes
+PERF_BUDGET_SECONDS = 5.0
+
+
+def _make_entry(idx: int, data_type: str, **kwargs) -> dict:
+    """Synthesize one timeline entry. Uses the same shape as Timeline writes."""
+    base = {
+        "entry_id": f"e{idx:06d}",
+        "ts": f"2026-05-12T{(idx % 24):02d}:{(idx % 60):02d}:00",
+        "data_type": data_type,
+        "by": kwargs.pop("by", "perf-fixture"),
+    }
+    base.update(kwargs)
+    return base
+
+
+def _build_fixture_lines(total: int) -> list[str]:
+    """Build a list of JSON-serialized timeline entries.
+
+    Layout:
+      - First TARGET_HISTORY_ROUNDS * 2 entries belong to TARGET_TASK_ID
+        (task_started + task_finished per round), simulating a multi-run task
+      - The rest is noise: task_appended / task_started / task_finished /
+        duplicate_msg_ingest for many other task_ids, scattered across threads
+    """
+    lines: list[str] = []
+
+    # Target task history entries (8 entries: 4 rounds × {started, finished})
+    for round_idx in range(TARGET_HISTORY_ROUNDS):
+        lines.append(json.dumps(_make_entry(
+            len(lines),
+            "task_started",
+            thread_id=f"T_PERF_THREAD_{round_idx % 4}",
+            task_id=TARGET_TASK_ID,
+            data={"run_id": f"r{round_idx}", "csid": f"csid_{round_idx}"},
+        ), ensure_ascii=False))
+        lines.append(json.dumps(_make_entry(
+            len(lines),
+            "task_finished",
+            thread_id=f"T_PERF_THREAD_{round_idx % 4}",
+            task_id=TARGET_TASK_ID,
+            data={"run_id": f"r{round_idx}", "status": "completed"},
+        ), ensure_ascii=False))
+
+    # Pad to TOTAL_ENTRIES with noise across non-target task ids
+    noise_data_types = (
+        "task_appended", "task_started", "task_finished", "duplicate_msg_ingest",
+        "msg_received", "thread_created",
+    )
+    remaining = total - len(lines)
+    for i in range(remaining):
+        dt = noise_data_types[i % len(noise_data_types)]
+        # ~5 % of noise also touches TARGET_TASK_ID via embedded data.task_id
+        # (exercises the "data.task_id" fallback path in task_history)
+        if i % 200 == 0:
+            entry = _make_entry(
+                len(lines), dt,
+                thread_id=f"T_PERF_THREAD_{i % 32}",
+                task_id=None,
+                data={"task_id": TARGET_TASK_ID, "run_id": f"noise_r{i}"},
+            )
+        else:
+            entry = _make_entry(
+                len(lines), dt,
+                thread_id=f"T_PERF_THREAD_{i % 32}",
+                task_id=f"T_NOISE_{i:06d}",
+                data={"prompt_head": f"noise prompt {i}"},
+            )
+        lines.append(json.dumps(entry, ensure_ascii=False))
+
+    return lines
+
+
+@pytest.mark.perf
+def test_t9_7b_task_history_perf_10000_entries(tmp_path: Path, monkeypatch):
+    """Real 10000-entry fixture; assert ``frago task history <id>`` ≤ 5s.
+
+    No mock / freeze / monkeypatch on time/clock — only HOME redirection so the
+    CLI reads the synthetic timeline. Wall-clock measured around CliRunner invoke.
+    """
+    home = tmp_path / "home"
+    timeline_dir = home / ".frago" / "timeline"
+    timeline_dir.mkdir(parents=True)
+    timeline_path = timeline_dir / "timeline.jsonl"
+
+    lines = _build_fixture_lines(TOTAL_ENTRIES)
+    assert len(lines) == TOTAL_ENTRIES, (
+        f"fixture builder gave {len(lines)} entries, expected {TOTAL_ENTRIES}"
+    )
+    timeline_path.write_text("\n".join(lines), encoding="utf-8")
+
+    # Sanity: fixture file is on disk and parseable
+    assert timeline_path.stat().st_size > 0
+
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+
+    runner = CliRunner()
+    start = time.monotonic()
+    result = runner.invoke(task_history, [TARGET_TASK_ID])
+    elapsed = time.monotonic() - start
+
+    assert result.exit_code == 0, (
+        f"task history exited {result.exit_code}: {result.output[:500]}"
+    )
+    payload = json.loads(result.output)
+    assert payload["task_id"] == TARGET_TASK_ID
+    # 4 rounds × 2 explicit entries (started/finished) plus the ~5% noise
+    # entries that mention TARGET_TASK_ID via data.task_id. We expect ≥ 8.
+    assert payload["count"] >= TARGET_HISTORY_ROUNDS * 2, (
+        f"expected at least {TARGET_HISTORY_ROUNDS * 2} entries for target, "
+        f"got {payload['count']}"
+    )
+
+    assert elapsed < PERF_BUDGET_SECONDS, (
+        f"task history scan over {TOTAL_ENTRIES} entries took "
+        f"{elapsed:.3f}s (budget {PERF_BUDGET_SECONDS}s)"
+    )


### PR DESCRIPTION
## Summary

Finish-implementation PR — 补完 spec 20260512-msg-task-board-redesign 字面要求剩余 6 项缺口 (orchestrator audit 揭穿, 上次 #67-#74 iteration close-out 是 fabrication). 单 PR 单分支, 5 commits 按 P1→P2 顺序.

**Base**: main @ a1875f6 (PR #74 merged)
**Branch**: feat/taskboard-finish-spec-gaps
**Commits**: 5 (含 1 个 deletion-only via gitignore 本地处理)
**Diff**: 8 files, +524 / -176 (净 +348)

## 6 项 GAP 逐条对照 (orchestrator audit + verification grep)

| ID | 缺口 | 实施 commit | 状态 |
|---|---|---|---|
| GAP-1 (P1) | scheduler.py `_message_cache` 字段 + 3 方法 + write site | aa618d4 | ✓ grep 仅余 docstring 提及 |
| GAP-2 (P1) | PA service `_reconcile_orphaned_messages` + `_scheduler._message_cache` 引用 | aa618d4 | ✓ grep 仅余 comment 提及 |
| GAP-3 (P1) | tests/unit/server/services/ingestion/{test_store,test_models}.py orphan | (local rm, gitignored) | ✓ pytest tests/unit/...ingestion/ 不再报 import error |
| GAP-4 (P1) | cli/task_commands.py 补 list / awaiting / active / stats | 1e94681 | ✓ `frago task --help` 含 4 新子命令 |
| GAP-5 (P2) | fold.py 拆独立模块 (spec line 46-47 NEW) — 路径 A | 5393953 | ✓ taskboard/fold.py 存在; board.fold 是 thin wrapper |
| GAP-6 (P2) | tests/server/test_timeline_query_perf.py T9.7b 10000 entries ≤5s | 4f757fa | ✓ 实测 0.30s |

## Commits

1. **aa618d4** `feat(taskboard): strip _message_cache shim (GAP-1 + GAP-2)`
2. **1e94681** `feat(cli): add frago task list / awaiting / active / stats (GAP-4)`
3. **5393953** `refactor(taskboard): extract fold algorithm to fold.py (GAP-5 path A)`
4. **4f757fa** `test(timeline): T9.7b 10000-entry task history perf test (GAP-6)`

GAP-3 不需要 commit: tests/unit/* 是 dev-local (gitignored), 删除 orphaned test 文件不进 git 历史; 实测 `pytest tests/unit/server/services/ingestion/` collection 不再报 import error.

## 验收线

- [x] AC1: 6 项 GAP grep verify 全部 clean (剩余命中均为 docstring / comment 提及 spec 章节, 符合 audit "除非历史变更 changelog" 例外)
- [x] AC2: `uv run pytest tests/server/ -v` 全绿 **62 passed** (含新增 T9.7b 1 case, 实测 0.30s)
- [x] AC3: 本次改动文件 `uv run ruff check` All checks passed (8 files, 0 violation). pre-existing src/ + tests/ violations 不在本 PR 范围
- [x] AC4: `uv run pytest tests/server/test_repeat_response_production_path.py -v` 3 cases 全绿 — 重复响应根因消除回归不退化
- [x] AC5: PR diff +524/-176 = 348 净行数, ≤ 800 单 PR 上限
- [ ] AC6: Yi append verb=approve 显式含 PR# — 待 Yi
- [ ] AC7: Ce append verb=verify_pass 含 PR# + 真跑 pytest 计数 — 待 Ce
- [ ] AC8: Orchestrator audit_clear — 待 orchestrator

## 立场维持 (charter 要求)

- 不 strangler / unilateral 改架构 (上次 #131/#152/#172 教训) ✓
- 不在 PR body 编造 "@Yi 同意了 X" — 全部决议引用具体 jsonl entry / spec 条款
- 实测超估则 ask @Yi 走 (iii) escape valve — 本次未超估, 单 PR ship
- class-level legacy_store 真删不在本次范围 (Yi #184 已 ack, 留独立 iteration)

## Test plan

- [x] pytest tests/server/ 62 passed + 0 skipped + 0 failed
- [x] pytest tests/server/test_timeline_query_perf.py 1 passed in 0.30s (under 5s budget)
- [x] pytest tests/server/test_repeat_response_production_path.py 3 cases pass (regression-free)
- [x] ruff check 本次改动 8 文件 All passed
- [x] grep AC1 GAP-1/2: 0 实质 import / 调用 残留
- [x] frago task --help 输出 list / awaiting / active / stats / history / mark

🤖 Generated with [Claude Code](https://claude.com/claude-code)
