### PR TITLE
feat(cli): add agent --resume option for team_orchestrator session reuse

### DIFF
--- a/src/frago/cli/agent_command.py
+++ b/src/frago/cli/agent_command.py
@@ -262,6 +262,13 @@ def verify_claude_working(timeout: int = 30) -> tuple[bool, str]:
     help="Use specified UUID as Claude Code session ID (for Executor traceability)"
 )
 @click.option(
+    "--resume",
+    "resume_session_id",
+    type=str,
+    default=None,
+    help="Resume an existing Claude Code session by UUID (uses claude --resume internally)."
+)
+@click.option(
     "--passthrough",
     is_flag=True,
     help="Pass through raw stream-json output (for Web UI or machine consumption)"
@@ -292,6 +299,7 @@ def agent(
     yes: bool,
     source: str,
     session_id: str | None,
+    resume_session_id: str | None,
     passthrough: bool,
     endpoint: str | None,
     api_key: str | None,
@@ -418,9 +426,16 @@ def agent(
             "--replay-user-messages",
         ])
 
-    # Use caller-provided session_id or generate a fresh one
-    target_session_id = session_id or str(uuid.uuid4())
-    cmd.extend(["--session-id", target_session_id])
+    # Resume mode vs new-session mode (mutually exclusive)
+    if session_id and resume_session_id:
+        click.echo("Error: --session-id and --resume are mutually exclusive", err=True)
+        raise click.Abort()
+    if resume_session_id:
+        target_session_id = resume_session_id
+        cmd.extend(["--resume", resume_session_id])
+    else:
+        target_session_id = session_id or str(uuid.uuid4())
+        cmd.extend(["--session-id", target_session_id])
 
     if model:
         cmd.extend(["--model", model])


### PR DESCRIPTION
## Summary
- 给 \`frago agent\` 加 \`--resume <UUID>\` 选项, 内部转发到 \`claude --resume\`
- team_orchestrator recipe 的 \`_fire_agent_resume()\` 硬依赖此选项 — 没有它 4 角色 dispatch 全部 \`Error: No such option: --resume\` 失败
- \`PLAYBOOK §11\` 把这条列为 orchestrator 任务硬前置条件
- 与现有 \`--session-id\` 互斥 (passing both → click.Abort)

## 历史背景
本变更在更早某次会话中开发完成并测通过, 但因任务中断从未独立 commit, 留在 git stash 中。最近 2 次 orchestrator 任务 (msg-task-redesign-finish / true-source) 中, stash 这种"非永久"载体导致改动反复被 lint/checkout 抹掉, 4 角色 team 实际只能跑单角色 (Kai)。

## Test plan
- [x] \`frago agent --help\` 输出含 \`--resume TEXT Resume an existing Claude Code session by UUID\`
- [x] ruff All checks passed (本文件)
- [x] mutually exclusive 校验 (--session-id + --resume 同传) 触发 click.Abort
- [ ] 启动 team_orchestrator dispatch 单角色实测 (merge 后下次任务自然验证)

🤖 Generated with [Claude Code](https://claude.com/claude-code)