### PR TITLE
fix(pa): inject PA system prompt via prefix_provider to survive subprocess restart

### DIFF
--- a/src/frago/server/services/agent_service.py
+++ b/src/frago/server/services/agent_service.py
@@ -12,6 +12,7 @@ import shutil
 import subprocess
 import sys
 import uuid
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -55,7 +56,13 @@ class AgentSession:
     the process continues running (degrades to detached mode).
     """
 
-    def __init__(self, internal_id: str, project_path: str):
+    def __init__(
+        self,
+        internal_id: str,
+        project_path: str,
+        *,
+        prefix_provider: Callable[[], str] | None = None,
+    ):
         self.internal_id = internal_id
         self.project_path = project_path
         self._process: subprocess.Popen | None = None
@@ -70,6 +77,10 @@ class AgentSession:
         self._pending_tool_calls: dict[str, dict[str, Any]] = {}
         # Optional callback for capturing complete assistant messages
         self._on_assistant_message: Any | None = None  # Callable[[str], None]
+        # Session-bound prompt prefix (e.g., PA system prompt + bootstrap).
+        # Invoked on every (re)start so identity/context survives the restart
+        # that send_message performs. None for plain agent sessions.
+        self._prefix_provider = prefix_provider
 
     def _get_frago_agent_command(self) -> list[str]:
         """Get frago agent command for subprocess."""
@@ -99,12 +110,27 @@ class AgentSession:
             self._process = None
             logger.info(f"Cleaned up old subprocess (PID: {old_pid})")
 
+    def _assemble_prompt(self, message: str) -> str:
+        """Prepend session-bound prefix to the caller-supplied message.
+
+        Called on every (re)start. When ``prefix_provider`` is set the prefix
+        is re-evaluated each time so dynamic state (e.g. PA bootstrap) is
+        always current. Empty message returns the prefix alone.
+        """
+        if self._prefix_provider is None:
+            return message
+        prefix = self._prefix_provider()
+        if not message:
+            return prefix
+        return f"{prefix}\n\n{message}"
+
     async def start(self, prompt: str) -> None:
         """Start agent process in attached mode.
 
-        A fresh Claude session is started each time; conversational
-        memory across messages is the caller's responsibility (PA
-        rebuilds its prompt from queue + memory each turn).
+        A fresh Claude session is started each time; per-turn user content
+        comes from ``prompt``, while any session-bound prefix (PA system
+        prompt + bootstrap, etc.) is supplied by ``prefix_provider`` and
+        re-attached on every (re)start.
         """
         # Kill old process before starting new one to prevent orphan leaks
         self._cleanup_old_process()
@@ -119,7 +145,7 @@ class AgentSession:
         log_dir = Path.home() / ".frago" / "logs"
         log_dir.mkdir(parents=True, exist_ok=True)
         prompt_file = log_dir / f"agent-attached-{self.internal_id[:8]}.txt"
-        prompt_file.write_text(prompt, encoding="utf-8")
+        prompt_file.write_text(self._assemble_prompt(prompt), encoding="utf-8")
         cmd.extend(["--prompt-file", str(prompt_file)])
 
         # FRAGO_PA marks this subprocess as a Primary Agent spawn so frago-hook
@@ -149,9 +175,12 @@ class AgentSession:
         """Send a follow-up message by restarting the attached subprocess.
 
         Each call kills the existing claude child and launches a fresh
-        ``frago agent`` invocation with the message as the new prompt.
-        Cross-message Claude-side memory is not preserved at this layer;
-        callers (PA) provide their own conversation context.
+        ``frago agent`` invocation. The new subprocess receives
+        ``prefix_provider() + message`` (when a prefix provider is set),
+        so session identity / bootstrap context survives the restart
+        without the caller having to re-attach it on every send.
+        Cross-message Claude-side conversational memory is still not
+        preserved at this layer.
         """
         # Stop current reader task before starting new process
         self._running = False
@@ -531,25 +560,35 @@ class AgentService:
 
     @classmethod
     async def start_task_attached(
-        cls, prompt: str, project_path: str | None = None
+        cls,
+        prompt: str,
+        project_path: str | None = None,
+        *,
+        prefix_provider: Callable[[], str] | None = None,
     ) -> dict[str, Any]:
         """Start agent task in attached mode with real-time streaming.
 
         Args:
             prompt: Task description/prompt.
             project_path: Optional project path context.
+            prefix_provider: Optional zero-arg callable returning a prompt
+                prefix re-evaluated on every (re)start. Use this to bind
+                a long-lived role (e.g. PA system prompt + bootstrap) to
+                the session — survives restarts triggered by send_message.
 
         Returns:
             Dictionary with internal_id, status, and project_path.
         """
-        if not prompt or not prompt.strip():
+        # Empty `prompt` is allowed only when a prefix_provider is bound —
+        # the prefix becomes the entire initial message.
+        if (not prompt or not prompt.strip()) and prefix_provider is None:
             return {"status": "error", "error": "Task description cannot be empty"}
 
         prompt = prompt.strip()
         internal_id = str(uuid.uuid4())
         cwd = project_path or str(Path.home())
 
-        session = AgentSession(internal_id, cwd)
+        session = AgentSession(internal_id, cwd, prefix_provider=prefix_provider)
 
         try:
             await session.start(prompt)

--- a/src/frago/server/services/primary_agent_service.py
+++ b/src/frago/server/services/primary_agent_service.py
@@ -264,12 +264,20 @@ class PrimaryAgentService:
 
         logger.info("PA session creating (reason=%s, seq=%d)", reason, self._heartbeat_seq)
 
-        bootstrap, reborn_reason = self._build_bootstrap_prompt(create_reason=reason)
-        prompt = PRIMARY_AGENT_SYSTEM_PROMPT + "\n\n" + bootstrap
+        # reborn_reason is only meaningful for the online-notification gate.
+        # The prefix itself is re-assembled on every (re)start by the
+        # AgentSession via the prefix_provider below, so a single restart
+        # triggered by send_message cannot strip PA identity / bootstrap.
+        _, reborn_reason = self._build_bootstrap_prompt(create_reason=reason)
+
+        def _pa_prefix_provider() -> str:
+            latest_bootstrap, _ = self._build_bootstrap_prompt(create_reason="message_dispatch")
+            return PRIMARY_AGENT_SYSTEM_PROMPT + "\n\n" + latest_bootstrap
 
         result = await AgentService.start_task_attached(
-            prompt=prompt,
+            prompt="",
             project_path=str(Path.home()),
+            prefix_provider=_pa_prefix_provider,
         )
         if result.get("status") != "ok":
             raise RuntimeError(

--- a/tests/server/test_agent_session_prefix_provider.py
+++ b/tests/server/test_agent_session_prefix_provider.py
@@ -1,0 +1,40 @@
+"""Regression tests for AgentSession.prefix_provider.
+
+Background: AgentSession.send_message restarts the underlying subprocess
+each time. Prior to the fix, the PA session's identity prompt (PA_SYSTEM_PROMPT
++ bootstrap) was lost on the first send_message because it was only embedded
+in the initial start() prompt. New subprocesses ran as vanilla frago agents
+with no PA identity or 4-action output protocol.
+
+Fix: AgentSession now holds a prefix_provider callable invoked on every
+(re)start to re-attach session-bound prefix.
+"""
+from frago.server.services.agent_service import AgentSession
+
+
+def test_assemble_prompt_no_prefix_provider_returns_message_unchanged():
+    sess = AgentSession("test-id", "/tmp")
+    assert sess._assemble_prompt("hello") == "hello"
+
+
+def test_assemble_prompt_with_prefix_provider_prepends_prefix():
+    sess = AgentSession("test-id", "/tmp", prefix_provider=lambda: "PREFIX")
+    assert sess._assemble_prompt("hello") == "PREFIX\n\nhello"
+
+
+def test_assemble_prompt_empty_message_returns_prefix_only():
+    sess = AgentSession("test-id", "/tmp", prefix_provider=lambda: "PREFIX")
+    assert sess._assemble_prompt("") == "PREFIX"
+
+
+def test_prefix_provider_re_evaluated_each_call():
+    counter = {"n": 0}
+
+    def provider() -> str:
+        counter["n"] += 1
+        return f"prefix-v{counter['n']}"
+
+    sess = AgentSession("test-id", "/tmp", prefix_provider=provider)
+    assert sess._assemble_prompt("a") == "prefix-v1\n\na"
+    assert sess._assemble_prompt("b") == "prefix-v2\n\nb"
+    assert counter["n"] == 2


### PR DESCRIPTION
## Summary
- 修复 PA 在 attached subprocess 重启时**静默丢失 PA_SYSTEM_PROMPT** 的契约陷阱
- 改动：把 prompt 前缀注入责任从调用方收回到 `AgentSession`，通过新增 `prefix_provider: Callable[[], str] | None` 字段实现，每次 `(re)start` 自动重评估并拼到 message 前面
- 影响文件：`agent_service.py`（+AgentSession.prefix_provider / _assemble_prompt / 兼容空 prompt）、`primary_agent_service.py`（_create_pa_session 改为传 prefix_provider 闭包）、`tests/server/test_agent_session_prefix_provider.py`（新增 4 个回归测试）

## Why
`AgentSession.send_message` 会 kill 旧子进程并起一个新的 `frago agent --prompt-file ...`，prompt-file 内容就是调用方传入的 message。这意味着 `_create_pa_session` 当初注入的 `PA_SYSTEM_PROMPT + bootstrap` **只对第一次启动那个进程有效**——第一次 `_send_to_pa` 就把它 kill 了，新进程里再也没有 PA 身份。

生产症状：飞书消息进来后 attached subprocess 跑成了裸 `frago agent`——不知道自己是决策中枢、不知道 4-action JSON 输出协议、不知道 reply/run/resume/schedule 字段定义。第一次输出"Jamey 需要做什么"等自然语言；纠正模板硬教 JSON 后把 channel/msg_id 填成 `<from_input>` 等占位符；下游 `task_lifecycle` 查不到 channel 对应的 notify_recipe，回复发送静默失败。

调研全过程见 `.claude/docs/spec-driven-plan/20260512-msg-task-board-redesign_bug.html`（左右对照：设计预期 vs 实际流程）。

## Design choice
两个候选：
- (A) `_send_to_pa` 每次手动拼接 PA_SYSTEM_PROMPT —— 1 处改动但**反护栏**：下个调用方仍会忘
- (B) ✅ `AgentSession` 持有 `prefix_provider`，自己负责拼接 —— 3 处机械改动但**护栏到位**：调用方不接触 system prompt，不可能忘

选 B。`AgentSession.send_message` 的 docstring 也同步更新，明确"prefix 由 session 对象自动续接，调用方只管 user msg"。

## Verification
- ✅ 单元 + server 测试 `730 passed`（含 4 个新增回归测试）
- ✅ `ruff check` All checks passed
- ✅ **端到端验证**：server 重启后实际发飞书消息，attached subprocess 的 prompt-file 首行就是 `你是 frago agent OS 的主进程调度器（Primary Agent）`，PA 出合法 JSON 决策 `[{"action":"reply","msg_id":"om_x100b...","channel":"feishu","text":"..."}]`（修复前 0 命中 PA system prompt 特征 + 编占位符；修复后命中 + 字段全部真实值）

## Test plan
- [x] `pytest tests/unit tests/server` 通过
- [x] `ruff check` 通过
- [x] server 重启后处理飞书消息时 attached subprocess jsonl 命中 PA system prompt 特征
- [x] PA 输出 channel 字段为真实值（feishu）而非占位符
- [ ] 飞书侧实际收到回复 — **本 PR 不覆盖**，被另一个独立 bug 阻塞（`task_lifecycle.reply` 只从 task_id 反查 reply_context，PA 直接对 msg 做 reply 时 chat_id/reply_context 全丢，feishu_send_message recipe exit 1）。另起 PR 修

🤖 Generated with [Claude Code](https://claude.com/claude-code)