### PR TITLE
fix(task_lifecycle): inject reply_context from msg_id when task_id is empty

### DIFF
--- a/src/frago/server/services/primary_agent_service.py
+++ b/src/frago/server/services/primary_agent_service.py
@@ -1085,7 +1085,7 @@ class PrimaryAgentService:
         if image_path:
             reply_params["image_path"] = image_path
         result = await asyncio.to_thread(
-            self._lifecycle.reply, task_id, channel, reply_params,
+            self._lifecycle.reply, task_id, channel, reply_params, msg_id=msg_id,
         )
 
         if result["status"] == "ok":

--- a/src/frago/server/services/task_lifecycle.py
+++ b/src/frago/server/services/task_lifecycle.py
@@ -187,11 +187,41 @@ class TaskLifecycle:
 
     # -- reply --
 
-    def reply(self, task_id: str, channel: str, reply_params: dict[str, Any]) -> dict[str, Any]:
+    @staticmethod
+    def _merge_reply_context(
+        reply_params: dict[str, Any], reply_context: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Build full notify-recipe params: text + reply_context + preserved attachments.
+
+        Attachment passthrough (html_body / file_path / image_path) was previously
+        dropped on the task path — see 2026-04-19 audit, problem 6.
+        """
+        full = {
+            "text": reply_params.get("text", ""),
+            "reply_context": reply_context,
+        }
+        for k in ("html_body", "file_path", "image_path"):
+            if reply_params.get(k):
+                full[k] = reply_params[k]
+        return full
+
+    def reply(
+        self,
+        task_id: str,
+        channel: str,
+        reply_params: dict[str, Any],
+        *,
+        msg_id: str = "",
+    ) -> dict[str, Any]:
         """Execute a reply via notify recipe. Returns {"status": "ok"/"error"}.
 
         Enriches params with reply_context (from board.Msg.source.reply_context),
         runs notify recipe. Caller (_send_reply) handles task status updates.
+
+        Resolution order for reply_context:
+        1. ``task_id`` non-empty → board task → task.reply_context
+        2. ``task_id`` empty and ``msg_id`` non-empty → board msg → msg.source.reply_context
+           (covers PA decisions that reply directly to a msg without creating a task)
         """
         if channel == "cli":
             return {"status": "ok"}
@@ -210,20 +240,17 @@ class TaskLifecycle:
                 channel = view.channel
 
             if view and view.reply_context:
-                full_params = {
-                    "text": reply_params.get("text", ""),
-                    "reply_context": view.reply_context,
-                }
-                if reply_params.get("html_body"):
-                    full_params["html_body"] = reply_params["html_body"]
-                # Preserve attachment fields — previously these were silently
-                # dropped whenever a task had reply_context, causing PA's
-                # file_path / image_path to vanish (problem 6 of 2026-04-19 audit).
-                if reply_params.get("file_path"):
-                    full_params["file_path"] = reply_params["file_path"]
-                if reply_params.get("image_path"):
-                    full_params["image_path"] = reply_params["image_path"]
-                reply_params = full_params
+                reply_params = self._merge_reply_context(reply_params, view.reply_context)
+        elif msg_id:
+            # Reply targets a msg directly (no task created). Board stores msg_id
+            # as f"{channel}:{msg_id}", PA decisions carry the bare id.
+            board = get_board()
+            board_msg_id = f"{channel}:{msg_id}"
+            board_msg = board._find_msg(board_msg_id)  # noqa: SLF001 — internal lookup
+            if board_msg and board_msg.source.reply_context:
+                reply_params = self._merge_reply_context(
+                    reply_params, board_msg.source.reply_context,
+                )
 
         # Find and run notify recipe for channel
         try:

--- a/tests/server/test_task_lifecycle_reply_msg_id.py
+++ b/tests/server/test_task_lifecycle_reply_msg_id.py
@@ -1,0 +1,55 @@
+"""Regression tests for TaskLifecycle.reply msg_id fallback path.
+
+Background: PA decisions sometimes reply directly to a msg without creating
+a task (task_id empty in the decision). Prior to this fix, reply() only
+injected reply_context when task_id was non-empty — bare msg_id path skipped
+the injection, so chat_id / message_id never reached the notify recipe.
+Symptom: feishu_send_message exited with code 1 because chat_id was missing.
+
+Fix: reply() now accepts msg_id as a keyword arg and falls back to looking up
+board.msg.source.reply_context when task_id is empty.
+"""
+from frago.server.services.task_lifecycle import TaskLifecycle
+
+
+def test_merge_preserves_text_and_injects_context():
+    out = TaskLifecycle._merge_reply_context(
+        {"text": "hi"},
+        {"chat_id": "oc_xxx", "message_id": "om_yyy"},
+    )
+    assert out == {
+        "text": "hi",
+        "reply_context": {"chat_id": "oc_xxx", "message_id": "om_yyy"},
+    }
+
+
+def test_merge_preserves_attachment_fields():
+    out = TaskLifecycle._merge_reply_context(
+        {
+            "text": "hi",
+            "file_path": "/tmp/a.pdf",
+            "image_path": "/tmp/b.png",
+            "html_body": "<p>hi</p>",
+        },
+        {"chat_id": "oc_xxx"},
+    )
+    assert out["file_path"] == "/tmp/a.pdf"
+    assert out["image_path"] == "/tmp/b.png"
+    assert out["html_body"] == "<p>hi</p>"
+    assert out["reply_context"] == {"chat_id": "oc_xxx"}
+
+
+def test_merge_drops_unknown_fields():
+    """Only the whitelisted attachment keys are forwarded — drops the rest."""
+    out = TaskLifecycle._merge_reply_context(
+        {"text": "hi", "unknown_field": "noise"},
+        {"chat_id": "oc_xxx"},
+    )
+    assert "unknown_field" not in out
+    assert set(out.keys()) == {"text", "reply_context"}
+
+
+def test_merge_empty_text_defaults_to_empty_string():
+    out = TaskLifecycle._merge_reply_context({}, {"chat_id": "oc_xxx"})
+    assert out["text"] == ""
+    assert out["reply_context"] == {"chat_id": "oc_xxx"}


### PR DESCRIPTION
## Summary
- 修复 `TaskLifecycle.reply` 只能从 task_id 反查 reply_context 的限制，新增 msg_id fallback 路径
- `reply()` 新增 `msg_id` keyword 参数；当 `task_id` 空且 `msg_id` 非空时，从 `board._find_msg(f"{channel}:{msg_id}").source.reply_context` 反查并注入
- 抽出 `_merge_reply_context` 静态 helper 复用 task_id 和 msg_id 两条路径的 attachment 保留逻辑
- `primary_agent_service._send_reply` 调用 lifecycle.reply 时传 `msg_id=msg_id`
- 新增 4 个回归测试覆盖 helper 各种输入组合

## Why
PA 决策有两条 reply 路径：
- **task_id 路径**：PA 决策附带 task_id（reply 一个由 run 创建的任务）→ task_lifecycle 从 task 反查 reply_context ✓
- **msg_id 路径**：PA 决策直接对一条 msg 做 reply（短回复，不创建 task）→ task_id 空、只有 msg_id

修复前 msg_id 路径**没有 reply_context 注入**——task_lifecycle 只把 `{"text": ...}` 传给 notify_recipe，`chat_id` / `message_id` 全丢。生产症状：PA 在 PR #81 修复后已经能出对的 reply 决策，但 `feishu_send_message` exit 1（缺 chat_id），飞书侧静默无回复。

## Verification
- ✅ `pytest tests/unit tests/server` 734 passed（+4 新增）
- ✅ `ruff check` All checks passed
- 端到端验证待 server 重启后实测

## Test plan
- [x] `_merge_reply_context` 单元测试覆盖：纯 text+context、attachment 字段保留、未知字段丢弃、空 text 默认
- [ ] 重启 server 后实际发飞书消息，feishu_send_message 应当 exit 0、飞书侧收到回复

## Relation to PR #81
PR #81 修了"PA 没有 system prompt"——让 PA 能产出**正确**的 reply 决策（含真实 channel + msg_id）；本 PR 修了下游"task_lifecycle 拿到正确决策但拼参数缺 reply_context"——让正确决策能真正送达飞书。两条独立 bug 串联起来才能让"飞书消息→PA→飞书回复"完整闭环。

🤖 Generated with [Claude Code](https://claude.com/claude-code)