### PR TITLE
feat(recipe): add diagnose_timeline_pa recipe

### DIFF
--- a/community-recipes/recipes/diagnose_timeline_pa/recipe.md
+++ b/community-recipes/recipes/diagnose_timeline_pa/recipe.md
@@ -1,0 +1,91 @@
+---
+name: diagnose_timeline_pa
+type: atomic
+runtime: python
+version: "1.0"
+description: "按时间窗采集本机 timeline / PA 运行数据，打成模板化诊断包（目录 + zip），含脱敏与安全红线过滤，供 frago 开发端定位 bug。"
+use_cases:
+  - "非开发使用者一条命令产出标准化诊断包回传开发团队"
+  - "按相对时长或绝对区间圈定问题发生的时间窗，只采集窗口内运行数据"
+  - "想分享诊断包又担心泄露正文/凭证时，开启 redact 产出脱敏包"
+output_targets:
+  - stdout
+  - file
+tags:
+  - diagnostics
+  - timeline
+  - primary-agent
+inputs:
+  start:
+    type: string
+    required: false
+    description: "窗口起点 ISO 时间（可带时区，不带按本地时区）。被 since 覆盖。"
+  end:
+    type: string
+    required: false
+    description: "窗口终点 ISO 时间，缺省=当前时刻。被 since 覆盖。"
+  since:
+    type: string
+    required: false
+    description: "相对时长 如 2h/30m/90s/1d；给定则窗口=[now-since, now] 并忽略 start/end。"
+  redact:
+    type: boolean
+    required: false
+    description: "脱敏开关，default=false。开启后抹掉正文字段、agents 只留清单。"
+  output_dir:
+    type: string
+    required: false
+    description: "输出根目录，default=~/.frago/.diagnostics。"
+outputs:
+  success:
+    type: boolean
+    description: "是否成功生成诊断包"
+  bundle_dir:
+    type: string
+    description: "诊断包目录绝对路径 {output_dir}/dia-{YYYYMMDD-HHMMSS}/"
+  archive:
+    type: string
+    description: "同名 zip 绝对路径"
+  counts:
+    type: object
+    description: "各数据类型计数，至少含 timeline/traces/server_log/agents"
+---
+
+# diagnose_timeline_pa
+
+## 功能描述
+在使用者本机按时间范围采集 timeline / PA (Primary Agent) 相关运行数据，打成一个模板化诊断包（目录 + 同名 zip），回传给 frago 开发团队定位潜在 bug。配方只做「采集 + 结构化 + 轻量索引」，不做深度分析。
+
+采集内容（全部按时间窗过滤后写入）：
+- `timeline.jsonl` — `~/.frago/timeline/timeline.jsonl`（不读 `.bak-*`）
+- `traces.jsonl` — `~/.frago/traces/trace-*.jsonl` 多日合并、按 ts 排序
+- `server.log` — `~/.frago/server.log` 及轮转 `.1/.2/.3`，含 traceback 续行，旧→新
+- `agents/` — `~/.frago/logs/` 下 agent 自由文本（mtime 在窗口内或 id 前缀命中窗口内 task_id）
+- `runtime/` — 脱敏后的 `runtime.json` / `config.json` / `schedules.json` / `feishu_poll_state.json` / `telemetry.json` / `.device_id` 及 server 存活状态
+
+产出两个跨机器格式一致的模板文件：`manifest.json`（机读）、`SUMMARY.md`（人读，含生命周期扫描诊断重点）。
+
+## 使用方式
+```
+frago recipe run diagnose_timeline_pa --params '{}'
+frago recipe run diagnose_timeline_pa --params '{"since":"30m","redact":true}'
+frago recipe run diagnose_timeline_pa --params '{"start":"2026-05-21T00:00:00","end":"2026-05-21T01:00:00"}'
+```
+窗口解析优先级：`since` > (`start`[, `end`]) > 默认 `since=2h`。
+
+## 前置条件
+- 本机存在 `~/.frago` 运行目录（部分源文件缺失会被健壮跳过，不影响整体成功）。
+- 无网络、无浏览器依赖，仅用 Python 标准库。
+
+## 预期输出
+stdout 单行 JSON：`{"success": true, "bundle_dir": "...", "archive": "...", "counts": {...}}`。
+诊断包目录与同名 zip 落在 `output_dir` 下。
+
+## 注意事项
+- 安全红线（硬排除）：永不采集 `recipes.local.json` / `profiles.json`；runtime/ 内所有 JSON 递归剔除 key 名含 `secret`/`token`/`key`/`password` 的字段。
+- 时区对齐：所有时间戳归一到本地 aware 时间后再做闭区间 `[start, end]` 过滤；server.log 毫秒逗号先转点。
+- 绝不对窗口内源数据做 `[:N]` 截断；SUMMARY 中 ERROR 为人读抽样，完整日志在 server.log 内。
+- 生命周期状态枚举对照 codebase（taskboard/models.py）：msg 终态 `{closed, dismissed}`，task 终态 `{completed, failed, resume_failed, replied}`。
+
+## 更新历史
+- 1.0 (2026-05-21): 初版，实现采集 + 结构化 + 模板化索引 + 脱敏 + 安全红线过滤。

--- a/community-recipes/recipes/diagnose_timeline_pa/recipe.py
+++ b/community-recipes/recipes/diagnose_timeline_pa/recipe.py
@@ -1,0 +1,937 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""diagnose_timeline_pa — 按时间窗采集 timeline / PA 运行数据，打成模板化诊断包。
+
+只做采集 + 结构化 + 轻量索引：多源 JSONL/日志按窗口过滤、跨格式时间戳归一、
+脱敏与安全红线过滤、打包 zip、生成 manifest.json / SUMMARY.md。
+"""
+
+import contextlib
+import json
+import os
+import platform
+import re
+import shutil
+import sys
+import zipfile
+from collections import Counter, OrderedDict
+from datetime import datetime, timedelta
+from pathlib import Path
+
+TOOL_VERSION = "1.0"
+
+# 系统本地时区（aware），所有时间戳归一的目标
+LOCAL_TZ = datetime.now().astimezone().tzinfo
+
+FRAGO_HOME = Path.home() / ".frago"
+
+# 正文类字段名：redact 时这些字段的值替换为 <redacted len=N>
+BODY_FIELDS = {
+    "prompt", "text", "result_summary", "summary",
+    "prompt_hint", "reason", "content", "root_summary",
+}
+
+# 安全红线：runtime/ 内 JSON 递归剔除 key 名（小写）含这些子串的字段
+SECRET_KEY_SUBSTR = ("secret", "token", "key", "password")
+
+# 生命周期状态枚举（对照 codebase: server/services/taskboard/models.py）
+MSG_TERMINAL = {"closed", "dismissed"}
+TASK_TERMINAL = {"completed", "failed", "resume_failed", "replied"}
+
+SINCE_RE = re.compile(r"^(\d+)([smhd])$")
+SERVER_HEADER_RE = re.compile(
+    r"^\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}),(\d{3})\]\s+(\S+)"
+)
+SINCE_UNIT = {"s": "seconds", "m": "minutes", "h": "hours", "d": "days"}
+
+# 日志消息聚合：把变量片段（uuid / 含字母+数字的 id / 纯数字）归一为占位符，
+# 使重复刷屏的告警折叠成一个模式。
+UUID_RE = re.compile(r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b")
+MIXED_ID_RE = re.compile(r"\b(?=[0-9A-Za-z]*[0-9])(?=[0-9A-Za-z]*[A-Za-z])[0-9A-Za-z]{5,}\b")
+NUM_RE = re.compile(r"\b\d+\b")
+
+
+def normalize_msg(s):
+    """归一日志消息正文，便于按模式聚合。"""
+    s = UUID_RE.sub("<uuid>", s)
+    s = MIXED_ID_RE.sub("<id>", s)
+    s = NUM_RE.sub("<n>", s)
+    return s.strip()
+
+
+# 从日志文本里抽 task_id 前缀（ULID 截断成 8 位、含字母+数字、大写 base32）
+LOG_TASKID_RE = re.compile(r"\b[0-9A-Z]{8}\b")
+
+
+def extract_task_prefixes(headers):
+    """从一组日志行抽出疑似 task_id 8 位前缀（既含数字又含字母）。"""
+    out = set()
+    for line in headers:
+        for tok in LOG_TASKID_RE.findall(line):
+            if any(c.isdigit() for c in tok) and any(c.isalpha() for c in tok):
+                out.add(tok)
+    return out
+
+
+def top_patterns(headers, top_n=10):
+    """把一组日志首行按归一后的消息体聚合，返回 [(pattern, count, example)]。"""
+    groups = {}  # norm_msg -> [count, first_raw_example]
+    for line in headers:
+        # 去掉 "[ts] LEVEL logger: " 前缀，只归一消息体
+        body = re.sub(r"^\[[^]]+\]\s+\S+\s+\S+?:\s*", "", line)
+        key = normalize_msg(body)
+        if key not in groups:
+            groups[key] = [0, line]
+        groups[key][0] += 1
+    ranked = sorted(groups.items(), key=lambda kv: kv[1][0], reverse=True)
+    return [(k, v[0], v[1]) for k, v in ranked[:top_n]]
+
+
+def log(msg):
+    print(msg, file=sys.stderr)
+
+
+def die(msg):
+    print(json.dumps({"success": False, "error": msg}, ensure_ascii=False), file=sys.stderr)
+    sys.exit(1)
+
+
+def normalize_to_local_aware(dt):
+    """naive -> 附本地时区；aware -> 原样。比较前必经此函数。"""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=LOCAL_TZ)
+    return dt
+
+
+# --------------------------------------------------------------------------- #
+# 窗口解析
+# --------------------------------------------------------------------------- #
+def resolve_window(params):
+    """优先级 since > (start[,end]) > 默认 since=2h。返回 (start, end) 本地 aware。"""
+    now = datetime.now().astimezone()
+    since = params.get("since")
+    start_raw = params.get("start")
+    end_raw = params.get("end")
+
+    if since is not None:
+        m = SINCE_RE.match(str(since).strip())
+        if not m:
+            die(f"非法 since 格式: {since!r}（应匹配 \\d+[smhd]，如 2h/30m/90s/1d）")
+        delta = timedelta(**{SINCE_UNIT[m.group(2)]: int(m.group(1))})
+        return now - delta, now
+
+    if start_raw is not None:
+        try:
+            window_start = normalize_to_local_aware(datetime.fromisoformat(str(start_raw)))
+        except ValueError as e:
+            die(f"start 解析失败: {start_raw!r} ({e})")
+        if end_raw is not None:
+            try:
+                window_end = normalize_to_local_aware(datetime.fromisoformat(str(end_raw)))
+            except ValueError as e:
+                die(f"end 解析失败: {end_raw!r} ({e})")
+        else:
+            window_end = now
+        if window_start > window_end:
+            die(f"窗口区间非法: start({window_start.isoformat()}) 晚于 end({window_end.isoformat()})")
+        return window_start, window_end
+
+    # 默认 since=2h
+    return now - timedelta(hours=2), now
+
+
+def in_window(dt, window):
+    """闭区间 [start, end] 判定。"""
+    return window[0] <= dt <= window[1]
+
+
+def parse_ts(value):
+    """解析任意源时间戳为本地 aware；失败返回 None。"""
+    if not value:
+        return None
+    try:
+        return normalize_to_local_aware(datetime.fromisoformat(str(value)))
+    except (ValueError, TypeError):
+        return None
+
+
+# --------------------------------------------------------------------------- #
+# 脱敏 / 安全红线
+# --------------------------------------------------------------------------- #
+def redact_body(obj):
+    """递归把正文类字段值替换为 <redacted len=N>。"""
+    if isinstance(obj, dict):
+        out = {}
+        for k, v in obj.items():
+            if k in BODY_FIELDS:
+                n = len(v) if isinstance(v, str) else len(json.dumps(v, ensure_ascii=False))
+                out[k] = f"<redacted len={n}>"
+            else:
+                out[k] = redact_body(v)
+        return out
+    if isinstance(obj, list):
+        return [redact_body(x) for x in obj]
+    return obj
+
+
+def strip_secret_keys(obj):
+    """递归剔除 key 名（小写）含 secret/token/key/password 的字段。"""
+    if isinstance(obj, dict):
+        out = {}
+        for k, v in obj.items():
+            kl = str(k).lower()
+            if any(s in kl for s in SECRET_KEY_SUBSTR):
+                continue
+            out[k] = strip_secret_keys(v)
+        return out
+    if isinstance(obj, list):
+        return [strip_secret_keys(x) for x in obj]
+    return obj
+
+
+# --------------------------------------------------------------------------- #
+# 采集：timeline
+# --------------------------------------------------------------------------- #
+def read_jsonl(path):
+    """逐行读 JSONL，产出 (entry, parse_error_count)。坏行跳过并计数。"""
+    entries, errors = [], 0
+    try:
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entries.append(json.loads(line))
+                except json.JSONDecodeError:
+                    errors += 1
+    except OSError:
+        pass
+    return entries, errors
+
+
+def collect_timeline(window):
+    """返回 (all_entries, window_entries, parse_errors)。all 用于生命周期重建。"""
+    path = FRAGO_HOME / "timeline" / "timeline.jsonl"
+    all_entries, errors = read_jsonl(path)
+    win = []
+    for e in all_entries:
+        dt = parse_ts(e.get("ts"))
+        if dt is not None and in_window(dt, window):
+            win.append(e)
+    return all_entries, win, errors
+
+
+def collect_traces(window):
+    """合并 trace-*.jsonl，窗口过滤后按 ts 排序。返回 (window_entries, parse_errors)。"""
+    traces_dir = FRAGO_HOME / "traces"
+    merged, errors = [], 0
+    if traces_dir.is_dir():
+        for path in sorted(traces_dir.glob("trace-*.jsonl")):
+            entries, errs = read_jsonl(path)
+            errors += errs
+            for e in entries:
+                dt = parse_ts(e.get("ts"))
+                if dt is not None and in_window(dt, window):
+                    merged.append((dt, e))
+    merged.sort(key=lambda x: x[0])
+    return [e for _, e in merged], errors
+
+
+# --------------------------------------------------------------------------- #
+# 采集：server.log（含轮转 + traceback 续行）
+# --------------------------------------------------------------------------- #
+def collect_server_log(window):
+    """返回 (in_window_lines, total, error_count, warning_count, error_headers, warning_headers)。
+
+    轮转顺序旧->新：server.log.3 -> .2 -> .1 -> server.log。
+    每条记录由首行时间戳判定窗口；无时间戳的续行跟随当前记录。
+    *_headers 是各 ERROR/WARNING 记录的首行，供调用方做模式聚合。
+    """
+    files = []
+    for name in ("server.log.3", "server.log.2", "server.log.1", "server.log"):
+        p = FRAGO_HOME / name
+        if p.exists():
+            files.append(p)
+
+    records = []  # [(dt_or_None, level_or_None, [lines])]
+    cur = None
+    for path in files:
+        try:
+            with open(path, encoding="utf-8", errors="replace") as f:
+                for line in f:
+                    line = line.rstrip("\n")
+                    m = SERVER_HEADER_RE.match(line)
+                    if m:
+                        ts_str = f"{m.group(1)}.{m.group(2)}"
+                        dt = parse_ts(ts_str)
+                        cur = [dt, m.group(3), [line]]
+                        records.append(cur)
+                    else:
+                        if cur is None:
+                            cur = [None, None, [line]]
+                            records.append(cur)
+                        else:
+                            cur[2].append(line)
+        except OSError:
+            continue
+
+    out_lines, total, errors, warnings = [], 0, 0, 0
+    error_headers, warning_headers = [], []
+    for dt, level, lines in records:
+        if dt is None or not in_window(dt, window):
+            continue
+        total += 1
+        out_lines.extend(lines)
+        if level == "ERROR":
+            errors += 1
+            error_headers.append(lines[0])
+        elif level == "WARNING":
+            warnings += 1
+            warning_headers.append(lines[0])
+    return out_lines, total, errors, warnings, error_headers, warning_headers
+
+
+# --------------------------------------------------------------------------- #
+# 采集：agents/
+# --------------------------------------------------------------------------- #
+def collect_agent_files(window, window_task_id8):
+    """挑选 logs/ 下纳入的 agent 自由文本文件。返回 [Path]。
+
+    纳入条件（满足其一）：mtime 落在窗口内；或文件名含窗口内 task_id 前 8 位。
+    """
+    logs_dir = FRAGO_HOME / "logs"
+    if not logs_dir.is_dir():
+        return []
+    patterns = ("agent-*.log", "agent-attached-*.txt", "prompt-*.txt", "console-*.txt")
+    candidates = {}
+    for pat in patterns:
+        for p in logs_dir.glob(pat):
+            candidates[p.name] = p
+    selected = []
+    for name, p in sorted(candidates.items()):
+        try:
+            mtime = normalize_to_local_aware(datetime.fromtimestamp(p.stat().st_mtime))
+        except OSError:
+            continue
+        include = in_window(mtime, window) or any(t8 in name for t8 in window_task_id8)
+        if include:
+            selected.append(p)
+    return selected
+
+
+# --------------------------------------------------------------------------- #
+# 生命周期重建（基于完整 timeline）
+# --------------------------------------------------------------------------- #
+def fold_lifecycle(all_entries):
+    """按 msg_id / task_id 折叠到最终状态。返回 (msg_status, task_status)。
+
+    状态来源（对照 codebase board._apply_entry）：
+      msg : msg_received(awaiting_decision) / task_appended(dispatched) /
+            msg_closed(closed) / msg_dismissed(dismissed)
+      task: task_appended(queued) / task_started(executing) / task_state(data.status) /
+            task_finished(data.status) / task_replied(replied)
+    按 timeline 原序重放，last-write-wins。
+    """
+    msg_status, task_status = {}, {}
+    for e in all_entries:
+        dt = e.get("data_type")
+        data = e.get("data") or {}
+        mid = e.get("msg_id")
+        tid = e.get("task_id")
+        if dt == "msg_received" and mid:
+            msg_status[mid] = data.get("status", "awaiting_decision")
+        elif dt == "msg_closed" and mid:
+            msg_status[mid] = data.get("status", "closed")
+        elif dt == "msg_dismissed" and mid:
+            msg_status[mid] = data.get("status", "dismissed")
+        elif dt == "task_appended":
+            if mid:
+                # task_appended 首次 append 使 msg 进入 dispatched（data.status 即 msg 新态）
+                msg_status[mid] = data.get("status", "dispatched")
+            if tid:
+                task_status[tid] = "queued"
+        elif dt == "task_started" and tid:
+            task_status[tid] = data.get("status", "executing")
+        elif dt == "task_state" and tid:
+            task_status[tid] = data.get("status", task_status.get(tid))
+        elif dt == "task_finished" and tid:
+            task_status[tid] = data.get("status", "completed")
+        elif dt == "task_replied" and tid:
+            task_status[tid] = data.get("status", "replied")
+    return msg_status, task_status
+
+
+def build_task_csid_map(all_entries):
+    """task_id -> csid（取该 task 最后一条 task_session_updated 的 csid）。"""
+    m = {}
+    for e in all_entries:
+        if e.get("data_type") == "task_session_updated":
+            tid = e.get("task_id")
+            csid = (e.get("data") or {}).get("csid")
+            if tid and csid:
+                m[tid] = csid
+    return m
+
+
+def count_recoveries_in_window(win_entries):
+    """窗口内每个 task 的 task_recovery 次数。"""
+    counts = Counter()
+    for e in win_entries:
+        if e.get("data_type") == "task_recovery" and e.get("task_id"):
+            counts[e["task_id"]] += 1
+    return counts
+
+
+# --------------------------------------------------------------------------- #
+# 采集：sessions/（csid 精确关联）
+# --------------------------------------------------------------------------- #
+def collect_sessions(csids, dest_dir, redact):
+    """按 csid 拷贝 ~/.frago/sessions/claude/<csid>/。返回已采集 csid 列表。
+
+    非 redact：拷 metadata.json / summary.json / steps.jsonl。
+    redact：只拷 metadata.json / summary.json（纯结构，无正文），不拷 steps.jsonl。
+    """
+    sessions_root = FRAGO_HOME / "sessions" / "claude"
+    collected = []
+    for csid in sorted(csids):
+        src = sessions_root / csid
+        if not src.is_dir():
+            continue
+        dst = dest_dir / csid
+        dst.mkdir(parents=True, exist_ok=True)
+        names = ["metadata.json", "summary.json"]
+        if not redact:
+            names.append("steps.jsonl")
+        copied_any = False
+        for name in names:
+            sp = src / name
+            if sp.exists():
+                try:
+                    shutil.copy2(sp, dst / name)
+                    copied_any = True
+                except OSError:
+                    pass
+        if copied_any:
+            collected.append(csid)
+        elif dst.exists() and not any(dst.iterdir()):
+            dst.rmdir()
+    return collected
+
+
+# --------------------------------------------------------------------------- #
+# runtime/ 快照
+# --------------------------------------------------------------------------- #
+def snapshot_runtime(runtime_dir):
+    """拷贝（脱敏后）运行时文件。返回 server 存活信息 dict。"""
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    json_files = [
+        "runtime.json", "config.json", "schedules.json",
+        "feishu_poll_state.json", "telemetry.json",
+    ]
+    for name in json_files:
+        src = FRAGO_HOME / name
+        if not src.exists():
+            continue
+        try:
+            data = json.loads(src.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        cleaned = strip_secret_keys(data)
+        (runtime_dir / name).write_text(
+            json.dumps(cleaned, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+
+    device_src = FRAGO_HOME / ".device_id"
+    if device_src.exists():
+        with contextlib.suppress(OSError):
+            shutil.copy2(device_src, runtime_dir / ".device_id")
+
+    return probe_server()
+
+
+def probe_server():
+    """读 server.pid 内容并探测进程存活。"""
+    pid_path = FRAGO_HOME / "server.pid"
+    pid, alive = None, False
+    if pid_path.exists():
+        try:
+            pid = int(pid_path.read_text(encoding="utf-8").strip())
+        except (OSError, ValueError):
+            pid = None
+        if pid is not None:
+            try:
+                os.kill(pid, 0)
+                alive = True
+            except OSError:
+                alive = False
+    return {"pid": pid, "alive": alive}
+
+
+def read_device_id():
+    p = FRAGO_HOME / ".device_id"
+    if p.exists():
+        try:
+            return p.read_text(encoding="utf-8").strip()
+        except OSError:
+            return None
+    return None
+
+
+def read_frago_version():
+    """从 config.json resources_version 取，取不到置 None。"""
+    p = FRAGO_HOME / "config.json"
+    if p.exists():
+        try:
+            data = json.loads(p.read_text(encoding="utf-8"))
+            v = data.get("resources_version")
+            if v:
+                return v
+        except (OSError, json.JSONDecodeError):
+            pass
+    return None
+
+
+def read_pa_session_id():
+    """config.json primary_agent.session_id（PA 自身会话 csid），取不到置 None。"""
+    p = FRAGO_HOME / "config.json"
+    if p.exists():
+        try:
+            data = json.loads(p.read_text(encoding="utf-8"))
+            return ((data.get("primary_agent") or {}).get("session_id")) or None
+        except (OSError, json.JSONDecodeError):
+            pass
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# 模板产出
+# --------------------------------------------------------------------------- #
+def build_summary(ctx):
+    """生成 SUMMARY.md 文本（模板化，跨机器格式一致）。"""
+    w = ctx["window"]
+    lines = []
+    lines.append("# frago 诊断包概要 (diagnose_timeline_pa)")
+    lines.append("")
+    lines.append("## 窗口与环境")
+    lines.append(f"- 窗口: `{w['start']}` ~ `{w['end']}`")
+    plat = ctx["platform"]
+    lines.append(f"- 平台: {plat['system']} {plat['release']} / {plat['machine']} / Python {plat['python']}")
+    lines.append(f"- frago 版本: {ctx['frago_version']}")
+    lines.append(f"- hostname: {ctx['hostname']}")
+    lines.append(f"- device_id: {ctx['device_id']}")
+    srv = ctx["server"]
+    lines.append(f"- server: pid={srv['pid']} alive={srv['alive']}")
+    lines.append(f"- 生成时间: {ctx['generated_at']}")
+    lines.append(f"- 脱敏 (redact): {ctx['redact']}")
+    lines.append("")
+
+    lines.append("## 计数")
+    lines.append("")
+    lines.append("### timeline (按 data_type)")
+    if ctx["timeline_by_type"]:
+        for k, v in ctx["timeline_by_type"].items():
+            lines.append(f"- {k}: {v}")
+    else:
+        lines.append("- (空)")
+    lines.append("")
+
+    lines.append("### traces (按 data_type / subkind)")
+    if ctx["traces_by_type"]:
+        for (dtp, sk), v in ctx["traces_by_type"].items():
+            lines.append(f"- {dtp} / {sk}: {v}")
+    else:
+        lines.append("- (空)")
+    lines.append("")
+
+    lines.append("### server.log")
+    lines.append(f"- 总记录数: {ctx['server_total']}")
+    lines.append(f"- ERROR: {ctx['server_errors']}")
+    lines.append(f"- WARNING: {ctx['server_warnings']}")
+    lines.append("")
+
+    lines.append("### sessions (csid 精确关联)")
+    lines.append(f"- 采集会话数: {len(ctx['sessions_collected'])}")
+    lines.append("")
+
+    lines.append("### agents (mtime 弱关联)")
+    lines.append(f"- 纳入文件数: {ctx['agents_count']}")
+    lines.append("")
+
+    if ctx["parse_errors"]:
+        lines.append(f"### 解析错误 (跳过的坏行): {ctx['parse_errors']}")
+        lines.append("")
+
+    lines.append("## 生命周期扫描 (诊断重点)")
+    lines.append("")
+    lines.append(f"- 窗口内活跃 msg: {ctx['window_msg_count']}，task: {ctx['window_task_count']}")
+    lines.append("")
+
+    lines.append(f"### 卡在非终态的 msg ({len(ctx['stuck_msgs'])})")
+    lines.append(f"  (终态集合: {sorted(MSG_TERMINAL)})")
+    if ctx["stuck_msgs"]:
+        for mid, st in ctx["stuck_msgs"]:
+            lines.append(f"- `{mid}` -> {st}")
+    else:
+        lines.append("- 无")
+    lines.append("")
+
+    lines.append(f"### 卡在非终态的 task ({len(ctx['stuck_tasks'])})")
+    lines.append(f"  (终态集合: {sorted(TASK_TERMINAL)})")
+    if ctx["stuck_tasks"]:
+        for tid, st in ctx["stuck_tasks"]:
+            lines.append(f"- `{tid}` -> {st}")
+    else:
+        lines.append("- 无")
+    lines.append("")
+
+    lines.append(f"### 失败任务 (窗口内活跃, {len(ctx['failed_tasks'])})")
+    lines.append("  (失败任务常触发恢复风暴，对照下方 server.log 聚合)")
+    if ctx["failed_tasks"]:
+        for ft in ctx["failed_tasks"]:
+            sess = "已采集" if ft["session_collected"] else "未采集"
+            src = "" if ft["in_window_timeline"] else " [仅窗口内日志引用]"
+            lines.append(
+                f"- `{ft['task_id']}` -> {ft['status']} | 窗口内 recovery {ft['recoveries_in_window']} 次"
+                f" | csid={ft['csid']} (session {sess}){src}"
+            )
+    else:
+        lines.append("- 无")
+    lines.append("")
+
+    lines.append("### boot / fold 次数")
+    if ctx["folds"]:
+        lines.append(f"- startup_fold_completed 共 {len(ctx['folds'])} 次:")
+        for f in ctx["folds"]:
+            lines.append(
+                f"  - {f['ts']}: entries_read={f['entries_read']} entries_skipped={f['entries_skipped']}"
+            )
+    else:
+        lines.append("- 无")
+    lines.append("")
+
+    lines.append(f"### reflection tick 次数: {ctx['reflection_ticks']}")
+    lines.append("")
+
+    lines.append(f"### server.log ERROR 模式聚合 (共 {ctx['server_errors']} 条)")
+    if ctx["error_patterns"]:
+        for pat, cnt, example in ctx["error_patterns"]:
+            lines.append(f"- ×{cnt}  `{pat}`")
+            lines.append(f"    例: {example}")
+    else:
+        lines.append("- 无")
+    lines.append("")
+
+    lines.append(f"### server.log WARNING 模式聚合 (共 {ctx['server_warnings']} 条)")
+    if ctx["warning_patterns"]:
+        for pat, cnt, example in ctx["warning_patterns"]:
+            lines.append(f"- ×{cnt}  `{pat}`")
+            lines.append(f"    例: {example}")
+    else:
+        lines.append("- 无")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------- #
+# main
+# --------------------------------------------------------------------------- #
+def main():
+    if len(sys.argv) < 2:
+        params = {}
+    else:
+        try:
+            params = json.loads(sys.argv[1])
+        except json.JSONDecodeError as e:
+            die(f"参数解析失败: {e}")
+
+    redact = bool(params.get("redact", False))
+    output_dir = Path(params.get("output_dir") or (FRAGO_HOME / ".diagnostics")).expanduser()
+
+    window = resolve_window(params)
+    log(f"[window] {window[0].isoformat()} ~ {window[1].isoformat()}")
+
+    # 输出目录可写性检查
+    try:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        probe = output_dir / ".write_probe"
+        probe.write_text("x", encoding="utf-8")
+        probe.unlink()
+    except OSError as e:
+        die(f"output_dir 不可写: {output_dir} ({e})")
+
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    bundle_name = f"dia-{stamp}"
+    bundle_dir = output_dir / bundle_name
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+    (bundle_dir / "agents").mkdir(exist_ok=True)
+    (bundle_dir / "sessions").mkdir(exist_ok=True)
+    (bundle_dir / "runtime").mkdir(exist_ok=True)
+
+    parse_errors = 0
+
+    # ---- timeline ----
+    log("[collect] timeline")
+    all_timeline, win_timeline, err = collect_timeline(window)
+    parse_errors += err
+    timeline_out = [redact_body(e) for e in win_timeline] if redact else win_timeline
+    with open(bundle_dir / "timeline.jsonl", "w", encoding="utf-8") as f:
+        for e in timeline_out:
+            f.write(json.dumps(e, ensure_ascii=False) + "\n")
+
+    # ---- traces ----
+    log("[collect] traces")
+    win_traces, err = collect_traces(window)
+    parse_errors += err
+    traces_out = [redact_body(e) for e in win_traces] if redact else win_traces
+    with open(bundle_dir / "traces.jsonl", "w", encoding="utf-8") as f:
+        for e in traces_out:
+            f.write(json.dumps(e, ensure_ascii=False) + "\n")
+
+    # ---- server.log ----
+    log("[collect] server.log")
+    srv_lines, srv_total, srv_errors, srv_warnings, error_headers, warning_headers = \
+        collect_server_log(window)
+    with open(bundle_dir / "server.log", "w", encoding="utf-8") as f:
+        if srv_lines:
+            f.write("\n".join(srv_lines) + "\n")
+
+    # ---- 窗口内 task_id 前 8 位（timeline + traces 并集），供 agents 纳入 ----
+    window_task_id8 = set()
+    for e in win_timeline:
+        tid = e.get("task_id")
+        if tid:
+            window_task_id8.add(str(tid)[:8])
+    for e in win_traces:
+        tid = e.get("task_id")
+        if tid:
+            window_task_id8.add(str(tid)[:8])
+
+    # ---- agents/ ----
+    log("[collect] agents")
+    agent_files = collect_agent_files(window, window_task_id8)
+    agents_dir = bundle_dir / "agents"
+    if redact:
+        manifest_items = []
+        for p in agent_files:
+            try:
+                st = p.stat()
+                manifest_items.append({
+                    "name": p.name,
+                    "size_bytes": st.st_size,
+                    "mtime": normalize_to_local_aware(
+                        datetime.fromtimestamp(st.st_mtime)
+                    ).isoformat(),
+                })
+            except OSError:
+                continue
+        (agents_dir / "manifest.json").write_text(
+            json.dumps(manifest_items, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+    else:
+        for p in agent_files:
+            try:
+                shutil.copy2(p, agents_dir / p.name)
+            except OSError:
+                continue
+    agents_count = len(agent_files)
+
+    # ---- runtime/ ----
+    log("[collect] runtime")
+    server_info = snapshot_runtime(bundle_dir / "runtime")
+
+    # ---- 生命周期重建 ----
+    log("[analyze] lifecycle fold")
+    msg_status, task_status = fold_lifecycle(all_timeline)
+    window_msg_ids = OrderedDict()
+    window_task_ids = OrderedDict()
+    for e in win_timeline:
+        mid = e.get("msg_id")
+        if mid:
+            window_msg_ids.setdefault(mid, True)
+        tid = e.get("task_id")
+        if tid:
+            window_task_ids.setdefault(tid, True)
+    for e in win_traces:  # traces 也可能引用 task_id
+        tid = e.get("task_id")
+        if tid:
+            window_task_ids.setdefault(tid, True)
+    stuck_msgs = [
+        (mid, msg_status.get(mid, "unknown"))
+        for mid in window_msg_ids
+        if msg_status.get(mid, "unknown") not in MSG_TERMINAL
+    ]
+    stuck_tasks = [
+        (tid, task_status.get(tid, "unknown"))
+        for tid in window_task_ids
+        if task_status.get(tid, "unknown") not in TASK_TERMINAL
+    ]
+
+    # ---- 窗口内 server.log ERROR/WARNING 文本里引用到的 task（病灶常只在日志里现身）----
+    #   把 timeline 全量 task_id 建 8 位前缀索引（一个前缀可能对应多个 task：ULID 同毫秒
+    #   生成的姊妹任务前 8 位相同，而 server.log 只截断到 8 位无法区分，故同前缀全部纳入）。
+    task_prefix_map = {}
+    for e in all_timeline:
+        tid = e.get("task_id")
+        if tid:
+            task_prefix_map.setdefault(str(tid)[:8], set()).add(tid)
+    log_task_prefixes = extract_task_prefixes(error_headers + warning_headers)
+    log_referenced_tids = set()
+    for p in log_task_prefixes:
+        log_referenced_tids |= task_prefix_map.get(p, set())
+
+    # 关注的 task = 窗口内 timeline/traces 活跃 + 窗口内日志引用，二者并集
+    tasks_of_interest = list(window_task_ids)
+    for t in log_referenced_tids:
+        if t not in window_task_ids:
+            tasks_of_interest.append(t)
+
+    # ---- sessions/（csid 精确关联，诊断主证据）----
+    log("[collect] sessions (csid-correlated)")
+    task_csid_map = build_task_csid_map(all_timeline)
+    window_csids = set()
+    for tid in tasks_of_interest:  # 关注 task -> 其 csid（从完整 timeline 反查）
+        c = task_csid_map.get(tid)
+        if c:
+            window_csids.add(c)
+    for e in win_timeline:  # 窗口内直接出现的 task_session_updated.csid
+        if e.get("data_type") == "task_session_updated":
+            c = (e.get("data") or {}).get("csid")
+            if c:
+                window_csids.add(c)
+    pa_session_id = read_pa_session_id()
+    if pa_session_id:
+        window_csids.add(pa_session_id)
+    collected_csids = collect_sessions(window_csids, bundle_dir / "sessions", redact)
+
+    # ---- 失败任务（关注 task 中终态 failed/resume_failed）----
+    recovery_counts = count_recoveries_in_window(win_timeline)
+    FAILED_STATES = {"failed", "resume_failed"}
+    failed_tasks = [
+        {
+            "task_id": tid,
+            "status": task_status.get(tid),
+            "csid": task_csid_map.get(tid),
+            "recoveries_in_window": recovery_counts.get(tid, 0),
+            "in_window_timeline": tid in window_task_ids,
+            "session_collected": task_csid_map.get(tid) in collected_csids,
+        }
+        for tid in tasks_of_interest
+        if task_status.get(tid) in FAILED_STATES
+    ]
+
+    # boot / fold（窗口内）
+    folds = []
+    for e in win_timeline:
+        if e.get("data_type") == "startup_fold_completed":
+            d = e.get("data") or {}
+            folds.append({
+                "ts": e.get("ts"),
+                "entries_read": d.get("entries_read"),
+                "entries_skipped": d.get("entries_skipped"),
+            })
+
+    # reflection ticks（窗口内 traces subkind=reflection）
+    reflection_ticks = sum(1 for e in win_traces if e.get("subkind") == "reflection")
+
+    # server.log 信号聚合（模式 + 计数 + 原文样例）
+    warning_patterns = top_patterns(warning_headers, top_n=10)
+    error_patterns = top_patterns(error_headers, top_n=10)
+
+    # ---- 计数 ----
+    timeline_by_type = Counter(e.get("data_type") for e in win_timeline)
+    traces_by_type = Counter(
+        (e.get("data_type"), e.get("subkind")) for e in win_traces
+    )
+    counts = {
+        "timeline": len(win_timeline),
+        "traces": len(win_traces),
+        "server_log": srv_total,
+        "sessions": len(collected_csids),
+        "agents": agents_count,
+        "server_log_errors": srv_errors,
+        "server_log_warnings": srv_warnings,
+        "parse_errors": parse_errors,
+        "stuck_msgs": len(stuck_msgs),
+        "stuck_tasks": len(stuck_tasks),
+        "failed_tasks": len(failed_tasks),
+    }
+
+    # ---- 模板：manifest.json ----
+    plat = {
+        "system": platform.system(),
+        "release": platform.release(),
+        "machine": platform.machine(),
+        "python": platform.python_version(),
+    }
+    manifest = {
+        "tool_version": TOOL_VERSION,
+        "generated_at": datetime.now().astimezone().isoformat(),
+        "params_raw": params,
+        "window": {"start": window[0].isoformat(), "end": window[1].isoformat()},
+        "frago_version": read_frago_version(),
+        "platform": plat,
+        "hostname": platform.node(),
+        "device_id": read_device_id(),
+        "server": server_info,
+        "counts": counts,
+        "failed_tasks": failed_tasks,
+        "sessions_collected": collected_csids,
+        "pa_session_id": pa_session_id,
+    }
+    (bundle_dir / "manifest.json").write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    # ---- 模板：SUMMARY.md ----
+    summary_ctx = {
+        "window": manifest["window"],
+        "platform": plat,
+        "frago_version": manifest["frago_version"],
+        "hostname": manifest["hostname"],
+        "device_id": manifest["device_id"],
+        "server": server_info,
+        "generated_at": manifest["generated_at"],
+        "redact": redact,
+        "timeline_by_type": dict(timeline_by_type),
+        "traces_by_type": traces_by_type,
+        "server_total": srv_total,
+        "server_errors": srv_errors,
+        "server_warnings": srv_warnings,
+        "agents_count": agents_count,
+        "parse_errors": parse_errors,
+        "window_msg_count": len(window_msg_ids),
+        "window_task_count": len(window_task_ids),
+        "stuck_msgs": stuck_msgs,
+        "stuck_tasks": stuck_tasks,
+        "failed_tasks": failed_tasks,
+        "sessions_collected": collected_csids,
+        "pa_session_id": pa_session_id,
+        "folds": folds,
+        "reflection_ticks": reflection_ticks,
+        "warning_patterns": warning_patterns,
+        "error_patterns": error_patterns,
+    }
+    (bundle_dir / "SUMMARY.md").write_text(build_summary(summary_ctx), encoding="utf-8")
+
+    # ---- 打包 zip（归档根目录即 dia-{stamp}/）----
+    log("[archive] zip")
+    archive_path = output_dir / f"{bundle_name}.zip"
+    with zipfile.ZipFile(archive_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for p in sorted(bundle_dir.rglob("*")):
+            if p.is_file():
+                zf.write(p, arcname=str(p.relative_to(output_dir)))
+
+    print(json.dumps({
+        "success": True,
+        "bundle_dir": str(bundle_dir.resolve()),
+        "archive": str(archive_path.resolve()),
+        "counts": counts,
+    }, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/community-recipes/recipes/diagnose_timeline_pa/spec.md
+++ b/community-recipes/recipes/diagnose_timeline_pa/spec.md
@@ -1,0 +1,159 @@
+# diagnose_timeline_pa
+
+## Goal
+给非开发的 frago 使用者用：在使用者本机按时间范围采集 timeline / PA (Primary Agent) 相关的运行数据，
+打成一个模板化的诊断包（目录 + 同名 zip），回传给 frago 开发团队定位潜在 bug。
+
+配方只负责「采集 + 结构化 + 轻量索引」三件事，不做深度分析（深度分析在开发端做）。
+输入是一个时间窗口（绝对区间或相对时长）与脱敏开关；输出是一个自包含的诊断包，
+含原始数据（窗口过滤后）、清洗后的运行时快照、以及两个跨机器格式一致的模板化文件
+（manifest.json 机读、SUMMARY.md 人读）。
+
+核心价值：使用者一条命令产出标准化诊断包，开发端拿到的每个包结构、字段、计数口径完全一致，
+不需要使用者懂内部数据格式，也不会误传含 secret 的敏感文件。
+
+## Type & Runtime
+- type: atomic
+- runtime: python
+
+选 python：纯本地数据处理——多源 JSONL/日志按时间窗过滤、跨格式时间戳归一、文件拷贝与脱敏、
+打包 zip、生成 manifest/SUMMARY。无浏览器、无网络，标准库即可（json / datetime / zipfile / shutil / platform / os）。
+
+## Inputs
+全部可选。窗口解析优先级：`since` > (`start`[, `end`]) > 默认 `since=2h`。
+
+- `start` (string, optional) — 窗口起点，ISO 时间，如 `2026-05-21T07:00:00`。可带时区；不带则按系统本地时区处理。
+- `end` (string, optional) — 窗口终点，ISO 时间。缺省 = 当前时刻（now）。
+- `since` (string, optional) — 相对时长字符串，如 `2h` / `30m` / `90s` / `1d`。给了 `since` 则窗口 = `[now - since, now]`，并忽略 `start`/`end`。
+- `redact` (boolean, optional, default=false) — 脱敏开关。开启后抹掉消息正文（只保留结构 / 状态 / 时间），用于使用者想分享脱敏包的场景。
+- `output_dir` (string, optional, default=`~/.frago/.diagnostics`) — 输出根目录。
+
+默认窗口：未给任何时间参数时取 `since=2h`，即 `[now - 2h, now]`。
+
+## Outputs
+stdout 打印单行 JSON：
+```json
+{"success": true, "bundle_dir": "...", "archive": "...", "counts": {...}}
+```
+
+- `success` (boolean) — 是否成功生成诊断包。
+- `bundle_dir` (string) — 诊断包目录绝对路径，形如 `{output_dir}/dia-{YYYYMMDD-HHMMSS}/`。
+- `archive` (string) — 同名 zip 绝对路径，形如 `{output_dir}/dia-{YYYYMMDD-HHMMSS}.zip`。
+- `counts` (object) — 各数据类型计数（与 manifest 中计数同源），至少含 timeline / traces / server_log / agents 各项条目数。
+
+output_targets: file, stdout
+
+诊断包目录结构：
+```
+dia-{YYYYMMDD-HHMMSS}/
+├── manifest.json          # 机读元数据（见下）
+├── SUMMARY.md             # 人读诊断概要（模板化，见下）
+├── timeline.jsonl         # 窗口内 timeline 事件
+├── traces.jsonl           # 窗口内 traces 事件（多日合并）
+├── server.log             # 窗口内 server 日志（含轮转、含 traceback 续行，旧→新）
+├── sessions/<csid>/       # csid 精确关联的 executor/PA 会话（诊断主证据）
+├── agents/                # 按 mtime 纳入的 agent 自由文本日志（弱补充；或 redact 时的清单）
+└── runtime/               # 脱敏后的运行时快照
+```
+
+## 关键约束：时区对齐（务必正确，否则窗口过滤错乱）
+不同数据源时间戳格式不一致，必须统一归一到「本地 aware 时间」再比较：
+- timeline 的 `ts` 是带时区的 ISO，例如 `2026-05-21T10:19:40.902916+08:00`
+- traces 的 `ts` 是裸本地时间（无时区），例如 `2026-05-21T11:59:43.378392`
+- server.log 时间是裸本地时间 `[2026-05-20 19:45:07,759]`（注意毫秒用逗号分隔）
+
+解析规则：
+- 用 `datetime.fromisoformat` 解析时间戳；若解析结果为 naive（无 tzinfo），附上系统本地时区（`datetime.now().astimezone().tzinfo`）。
+- 使用者传入的 `start` / `end` 与计算 `now` 同样按本地 aware 处理后再参与比较。
+- server.log 时间需先把毫秒分隔的逗号换成点（`,759` → `.759`）再 `fromisoformat`。
+- 窗口判定为闭区间 `[window_start, window_end]`。
+
+NEVER 对任何源数据做 `[:N]` 截断：窗口内内容必须完整保留。
+
+## 采集内容（全部按时间窗过滤后写入诊断包）
+1. **timeline.jsonl** — 源：`~/.frago/timeline/timeline.jsonl`，逐行 JSON。保留 `ts` 落在窗口内的事件，原序输出。
+   （不读 `.bak-*` 备份文件。）
+2. **traces.jsonl** — 源：`~/.frago/traces/trace-*.jsonl`（多日文件合并）。每行有 `ts`（裸本地）、`data_type`、`subkind`、`task_id`、`msg_id`、`thread_id`、`event`。按窗口过滤，合并后按 `ts` 排序输出。
+3. **server.log** — 源：`~/.frago/server.log` 及轮转 `server.log.1` / `.2` / `.3`。
+   - 格式：`[YYYY-MM-DD HH:MM:SS,mmm] LEVEL logger: message`。
+   - 多行 traceback 的续行没有时间戳，必须跟随其首行记录一起，按首行时间戳判定是否在窗口内。
+   - 跨所有轮转文件合并后，按时间从旧到新输出。
+4. **sessions/**（精确关联，诊断主证据）— 源：`~/.frago/sessions/claude/<csid>/`。
+   - **关联链**（实测确立）：taskboard 的 `task_id`（ULID）→ 完整 timeline 中该 task 最后一条 `task_session_updated` 的 `data.csid`（claude session id, UUID）→ `~/.frago/sessions/claude/<csid>/`（含 `metadata.json` / `summary.json` / `steps.jsonl`，是 executor/PA 的结构化会话记录）。
+   - **为什么不靠 agents 日志关联**：`logs/agent-{id8}.log` 的 id 是 `agent_service` 内部自生成的 uuid，与 timeline 的 `task_id` 是两套独立 id 空间，实测在 timeline/traces 中 0 命中，无法反查。csid 才是唯一能精确关联到 task 的桥。
+   - 选取范围（取并集）：① 窗口内有活动的 task_id（含仅在窗口内 `task_recovery` 的）经「完整 timeline」反查到的 csid；② 窗口内 `task_session_updated` 直接出现的 csid；③ `config.json` 的 `primary_agent.session_id`（PA 自身会话）。
+   - 体积：单个 task session 多为 KB 级；整个 sessions 库可达百 MB——**只采选中的 csid，绝不全采**。
+   - 拷贝到 `sessions/<csid>/`：非 redact 全拷；redact 时只拷 `metadata.json` / `summary.json`（纯结构/计数，无正文），不拷 `steps.jsonl`。
+   - 不读取 `~/.claude/projects/` 下的原始 Claude 会话（越界 + 隐私），只用 frago 自己的 `~/.frago/sessions`。
+5. **agents/**（尽力补充，非主证据）— 源：`~/.frago/logs/` 下 `agent-*.log` / `agent-attached-*.txt` / `prompt-*.txt` / `console-*.txt`。
+   - 文件内部无逐行时间戳且 id 无法与 task 关联，**仅按 mtime 落在窗口内**纳入（前缀匹配实测不命中，作弱条件保留）。已知局限：若某 task 在窗口内只是被 recovery、其 agent 日志写于更早时段，则采不到——精确证据走 sessions/ 那条链。
+   - 纳入文件原样拷贝到 `agents/`（redact 行为见下）。
+6. **runtime/** — 拷贝（脱敏后）以下文件：`runtime.json`、`config.json`、`schedules.json`、`feishu_poll_state.json`、`telemetry.json`、`.device_id`；并记录 `server.pid` 内容及该进程存活状态（`os.kill(pid, 0)` 探测）。
+
+## 永不采集（安全红线，硬排除）
+- `~/.frago/recipes.local.json`（含 secrets）
+- `~/.frago/profiles.json`
+- 任何 `.env`、`FRAGO_SECRETS`、以及含 `token` / `key` / `password` / `secret` 字样的字段
+- `config.json` 拷贝前递归剔除「key 名（小写后）含 `secret` / `token` / `key` / `password` 的字段」，再写入 `runtime/`。
+
+## redact 开启时的行为
+- timeline / traces 中的正文类字段，其值替换为 `<redacted len=N>`（N 为原值字符串长度）。
+  正文类字段名（在 `data` 及顶层中匹配）：`prompt`、`text`、`result_summary`、`summary`、`prompt_hint`、`reason`、`content`、`root_summary`。
+- `agents/` 下的自由文本文件不拷贝正文，改为写一份清单 `agents/manifest.json`（每项：文件名 / 大小 bytes / mtime ISO）。
+
+## 产出模板（两个文件跨机器格式必须一致）
+**manifest.json**（机读）至少含：
+- `tool_version`：采集工具（本配方）版本
+- `generated_at`：生成时间（ISO，本地 aware）
+- `params_raw`：原始输入参数
+- `window`：解析后的窗口 `{start, end}`（ISO，本地 aware）
+- `frago_version`：frago 版本
+- `platform`：`{system, release, machine, python}`（取自 `platform` 模块）
+- `hostname`、`device_id`（取自 `~/.frago/.device_id`）
+- `server`：`{pid, alive}`
+- `counts`：各项计数（与 stdout 的 counts 同源）
+
+**SUMMARY.md**（人读，模板化，跨机器格式一致）含：
+- 窗口与环境（窗口区间、平台、frago 版本、hostname、device_id、server 存活状态）
+- 各 data_type 计数：
+  - timeline 按 `data_type`
+  - traces 按 `data_type` / `subkind`
+  - server.log 总数 / ERROR 数 / WARNING 数
+  - agents 文件数
+- **生命周期扫描（诊断重点）**：基于完整 timeline 重建每个 msg / task 的最终状态，对「窗口内有活动」的对象：
+  - 标出仍处于非终态的 msg（未到 `closed` / `dismissed`）与 task（未到 `completed` / `failed` / `resume_failed` / `replied`）
+  - **失败任务**：列出窗口内活跃且最终态为 `failed` / `resume_failed` 的 task，附其 csid、窗口内 `task_recovery` 次数、对应 session 是否已采集——失败任务常引发恢复风暴，是诊断重点
+  - 列出 boot/fold 次数（`startup_fold_completed` 的 `entries_read` / `entries_skipped`）
+  - 列出 reflection tick 次数
+- **server.log 信号聚合**（不止抽样）：
+  - WARNING / ERROR 各做「模式聚合」——把消息里的 ULID / UUID / 数字归一为占位符后按出现次数排序，列 top N（每条带原文样例 + 计数）。重复刷屏的告警（如 `FAILED task <id> already recovered <n> times` ×164）必须以聚合形式直接出现在 SUMMARY，而不是只给一个总数让人去翻原始日志。
+
+## Error Scenarios
+- 源文件 / 目录缺失（其他使用者机器上可能没有某些文件）→ 跳过该项，计数置 0，不报错；其余继续采集。
+- `since` 格式非法（不匹配 `\d+[smhd]`）→ exit 非 0，stderr 给出清晰错误。
+- `start` / `end` 解析失败 → exit 非 0，stderr 指明哪个参数解析失败。
+- `start` 晚于 `end` → exit 非 0，stderr 提示窗口区间非法。
+- `output_dir` 不可写 → exit 非 0，stderr 提示。
+- timeline / traces 某行非法 JSON → 跳过该行，计入 `parse_errors` 计数，不中断。
+- server.pid 文件缺失或进程不存在 → `server.alive=false`，不报错。
+- 整体目标：对所有源文件缺失 / 损坏要健壮，能产出尽量完整的诊断包，绝不因单个源失败而整体失败。
+
+## Test Cases
+1. 默认窗口：`frago recipe run diagnose_timeline_pa --params '{}'`
+   → stdout `success=true`，`bundle_dir` 与 `archive` 路径存在，`counts` 含 timeline/traces/server_log/agents 各项；窗口 = 最近 2h。
+2. 相对窗口 + 脱敏：`frago recipe run diagnose_timeline_pa --params '{"since":"30m","redact":true}'`
+   → 包内 timeline.jsonl 正文字段为 `<redacted len=N>`；`agents/manifest.json` 存在且无正文文件。
+3. 绝对窗口：`frago recipe run diagnose_timeline_pa --params '{"start":"2026-05-21T00:00:00","end":"2026-05-21T01:00:00"}'`
+   → 仅含该 1 小时内事件；manifest `window` 与传入一致（归一为本地 aware）。
+4. 安全红线：任意参数运行后，`bundle_dir` 内全树 grep `token`/`secret`/`password` 字段值 → 无命中；不含 `recipes.local.json` / `profiles.json`。
+5. 健壮性：临时把 `~/.frago/traces` 改名后运行 → 仍 `success=true`，traces 计数为 0，其余项正常。
+
+## 实现说明
+- 时间戳归一是本配方最易错处：所有比较前都过 `normalize_to_local_aware(dt)`；naive → 附本地时区，aware → 原样。
+- 生命周期重建用「完整 timeline」（不是窗口过滤后的），按 msg_id / task_id 折叠到最终状态，再用「窗口内是否出现该 id」判定是否纳入 SUMMARY 的非终态告警。
+  - 终态参考（本机观测）：msg `closed`；task `replied` / `completed` / `failed`。中间态：msg `awaiting_decision` / `dispatched`；task `dispatched` / `executing`。
+  - 实现时按「不在终态集合即视为非终态」判定，终态/非终态集合以代码侧实际 status 枚举为准，NEVER 硬编码假设的状态名（如 `queued`/`started`/`finished` 本机未观测到，需对照 codebase 校正）。
+- traces 同时带 `data_type` 与 `subkind`，SUMMARY 的 traces 计数按二者交叉分组。
+- agents/ 纳入用到的 task_id 前缀集合，从「窗口内 timeline + traces 的 task_id 前 8 位」取并集。
+- zip 打包用 `zipfile`，归档根目录即 `dia-{stamp}/`，与目录内容一致。
+- frago 版本可从 `~/.frago/config.json` 的 `resources_version` 或 `frago --version` 取，取不到则置 `null`，不报错。


### PR DESCRIPTION
## New Recipe: diagnose_timeline_pa

**Type:** atomic
**Runtime:** python
**Version:** 1.0

### Description

按时间窗采集本机 timeline / PA 运行数据，打成模板化诊断包（目录 + zip），含脱敏与安全红线过滤，供 frago 开发端定位 bug。

### Use Cases

- 非开发使用者一条命令产出标准化诊断包回传开发团队
- 按相对时长或绝对区间圈定问题发生的时间窗，只采集窗口内运行数据
- 想分享诊断包又担心泄露正文/凭证时，开启 redact 产出脱敏包

---

*Submitted via `frago recipe share`*
