### PR TITLE
feat(recipe): add transcript_completion recipe

### DIFF
--- a/community-recipes/recipes/transcript_completion/recipe.md
+++ b/community-recipes/recipes/transcript_completion/recipe.md
@@ -1,0 +1,96 @@
+---
+name: transcript_completion
+type: atomic
+runtime: python
+version: "1.0.0"
+description: "解析 Claude Code session JSONL，用权威 stop_reason 判定最新一轮是否答完并抽取该轮 assistant 最终文本。query 一次性查询 / watch 长驻事件式上报，watch 形态可由 daemon supervisor 托管"
+use_cases:
+  - "query：给定 session_id+cwd 或 path，同步判定 transcript 尾部最新一轮是否完成 + 取最终文本（供 tmux 完成判定采信权威信号而非读屏）"
+  - "watch：watchdog 盯单个 jsonl，检测到一轮完成翻转时向 stdout 打一行 turn_complete 事件，供 daemon supervisor 流式消费"
+  - "冻结恢复：拿到 session id → locate_transcript 定位文件 → 解析尾部"
+output_targets:
+  - stdout
+tags:
+  - transcript
+  - jsonl
+  - completion-detection
+  - claude-session
+  - tmux
+  - daemon
+  - watch
+daemon: true
+restart_policy: on-failure
+inputs:
+  session_id:
+    type: string
+    required: false
+    description: "目标 Claude session id（确定性定位：~/.claude/projects/<encode(cwd)>/<session_id>.jsonl）"
+  cwd:
+    type: string
+    required: false
+    description: "目标会话的工作目录，配合 session_id 算编码路径；缺省时回退扫描所有 project 目录"
+  path:
+    type: string
+    required: false
+    description: "或直接给 transcript jsonl 的绝对路径（优先级高于 session_id）"
+  mode:
+    type: string
+    required: false
+    description: "query=一次性查询（默认） | watch=watchdog 长驻事件式上报"
+outputs:
+  type:
+    type: string
+    description: "事件类型：completion（query 结果）| turn_complete / turn_running（watch 事件）| error"
+  done:
+    type: boolean
+    description: "最新一轮是否真答完（stop_reason ∈ {end_turn, stop_sequence, max_tokens}）"
+  stop_reason:
+    type: string
+    description: "终结记录的 stop_reason（done 的依据）"
+  final_text:
+    type: string
+    description: "该轮 assistant 最终文本（含 JSON 决策原文）"
+  pending_tool_use:
+    type: boolean
+    description: "末尾是否还挂着 tool_use（stop_reason==tool_use）"
+  session_id:
+    type: string
+    description: "关联的 session id"
+  source_path:
+    type: string
+    description: "解析的 transcript 文件路径"
+dependencies: []
+flow:
+  - step: 1
+    action: "resolve_target"
+    description: "由 path 或 (session_id + cwd) 经 locate_transcript 定位 jsonl 文件"
+  - step: 2
+    action: "evaluate_or_watch"
+    description: "query：evaluate_file 判尾部一轮 + 抽文本，打一行 JSON；watch：SessionFileHandler 盯文件，done 翻转时打 turn_complete 事件行"
+---
+
+# transcript_completion
+
+把 spec `20260624-transcript-completion-recipe` 的解析核心（`frago.server.services.transcript_completion`）封装成配方。完成判定的权威信号是 Claude Code 写进 session JSONL 的 `message.stop_reason`，不读屏。配方复用 `claude_sessions` / `monitor` / `parser` 的既有解析，自身不重写 JSONL 解析。
+
+## 两种形态
+
+- `mode=query`（默认）：被调用即解析当前 transcript 尾部，向 stdout 打一行结构化 JSON（`type=completion`），供 tmux 完成判定同步采信。
+- `mode=watch`：用 watchdog 盯单个 jsonl，检测到「最新一轮是否答完」翻转为 True 时打一行 `type=turn_complete` 事件；进程常驻不退出，可声明 `daemon: true` 由工程一的 RecipeSupervisor 托管、崩溃自愈。
+
+## 调用示例
+
+```
+# 一次性查询（直接给文件路径）
+frago recipe run transcript_completion --params '{"path":"~/.claude/projects/-Users-frago-Repos-frago/<sid>.jsonl","mode":"query"}'
+
+# 一次性查询（给 session_id + cwd，确定性定位）
+frago recipe run transcript_completion --params '{"session_id":"<sid>","cwd":"/Users/frago/Repos/frago","mode":"query"}'
+
+# 长驻 watch（供 supervisor 托管；会持续输出事件行、不退出）
+frago recipe run transcript_completion --params '{"path":"<jsonl>","mode":"watch"}'
+```
+
+## 运行环境
+
+配方导入 `frago` 包复用解析核心，需在已安装 frago 的环境（frago venv）下运行——这正是 `frago recipe run` 与 server 派生子进程的运行环境，因此脚本不带 PEP 723 隔离声明（带了会让 uv 用隔离环境、frago 不可导入）。`watch` 形态依赖 `watchdog`（frago 既有依赖）。

--- a/community-recipes/recipes/transcript_completion/recipe.py
+++ b/community-recipes/recipes/transcript_completion/recipe.py
@@ -1,0 +1,150 @@
+"""Recipe: transcript_completion.
+
+Parse a Claude Code session JSONL and report whether the latest turn finished
+plus the assistant's final text, using the authoritative ``stop_reason`` signal.
+
+Two forms, sharing the Phase-1 pure core (``frago.server.services.transcript_completion``):
+  - mode=query (default): one-shot — emit a single JSON line for the tail verdict.
+  - mode=watch: long-running — watch the file, emit an event line each time the
+    "latest turn done" verdict flips. Runs forever; meant to be supervised by the
+    daemon supervisor (spec 20260624-recipe-daemon-supervisor).
+
+No PEP 723 block on purpose: this recipe imports the ``frago`` package, so it must
+run inside the frago venv (where ``frago recipe run`` and server-spawned children
+already run). A PEP 723 block would make uv use an isolated env where frago is
+not importable.
+"""
+
+import json
+import os
+import sys
+
+from frago.server.services.transcript_completion import (
+    TurnCompletion,
+    evaluate_file,
+    locate_transcript,
+)
+
+
+def log(msg: str) -> None:
+    print(msg, file=sys.stderr, flush=True)
+
+
+def emit(obj: dict) -> None:
+    print(json.dumps(obj, ensure_ascii=False), flush=True)
+
+
+def parse_params() -> dict:
+    """Recipe params arrive as a JSON string in argv[1] (see runner._run_python)."""
+    if len(sys.argv) > 1 and sys.argv[1].strip():
+        try:
+            data = json.loads(sys.argv[1])
+            if isinstance(data, dict):
+                return data
+        except json.JSONDecodeError:
+            pass
+    return {}
+
+
+def resolve_target(params: dict):
+    """Return the transcript Path from ``path`` or ``session_id`` (+ optional cwd)."""
+    raw_path = params.get("path")
+    if isinstance(raw_path, str) and raw_path.strip():
+        from pathlib import Path
+
+        return Path(os.path.expanduser(raw_path.strip()))
+    session_id = params.get("session_id")
+    if isinstance(session_id, str) and session_id.strip():
+        cwd = params.get("cwd")
+        return locate_transcript(session_id.strip(), cwd=cwd if isinstance(cwd, str) else None)
+    return None
+
+
+def _verdict_payload(event_type: str, tc: TurnCompletion) -> dict:
+    return {
+        "type": event_type,
+        "done": tc.done,
+        "stop_reason": tc.stop_reason,
+        "final_text": tc.final_text,
+        "pending_tool_use": tc.pending_tool_use,
+        "request_id": tc.request_id,
+        "session_id": tc.session_id,
+        "source_path": tc.source_path,
+    }
+
+
+def run_query(target) -> int:
+    if target is None:
+        emit({"type": "error", "error": "could not resolve transcript (need path or session_id)"})
+        return 1
+    tc = evaluate_file(target)
+    emit(_verdict_payload("completion", tc))
+    return 0
+
+
+def run_watch(target) -> int:
+    """Watch a single transcript; emit an event each time the done-verdict flips."""
+    if target is None:
+        emit({"type": "error", "error": "could not resolve transcript (need path or session_id)"})
+        return 1
+
+    import threading
+
+    from watchdog.observers import Observer
+
+    from frago.session.monitor import SessionFileHandler
+
+    # Resolve symlinks so the watchdog event path (which the OS may report via
+    # the real path, e.g. /private/var on macOS) matches the handler's exact
+    # target-file filter.
+    target = target.resolve()
+    target_str = str(target)
+    state = {"last_done": None}
+
+    def evaluate_and_emit() -> None:
+        # Completion is a tail property; re-read the file via the reused core
+        # rather than threading incremental record accumulation.
+        tc = evaluate_file(target)
+        if tc.done != state["last_done"]:
+            state["last_done"] = tc.done
+            emit(_verdict_payload("turn_complete" if tc.done else "turn_running", tc))
+
+    # SessionFileHandler fires on_new_records only when the target file gains
+    # records; we use it purely as a "something changed" signal and re-evaluate.
+    handler = SessionFileHandler(
+        on_new_records=lambda _path, _records: evaluate_and_emit(),
+        target_file=target_str,
+    )
+
+    # Emit the initial verdict so consumers get current state immediately.
+    if target.exists():
+        evaluate_and_emit()
+
+    observer = Observer()
+    observer.schedule(handler, os.path.dirname(target_str), recursive=False)
+    observer.start()
+    log(f"transcript_completion watching {target_str}")
+    try:
+        threading.Event().wait()  # run until killed by the supervisor
+    except KeyboardInterrupt:
+        pass
+    finally:
+        observer.stop()
+        observer.join(timeout=2)
+    return 0
+
+
+def main() -> int:
+    params = parse_params()
+    mode = params.get("mode") or "query"
+    target = resolve_target(params)
+    if mode == "watch":
+        return run_watch(target)
+    if mode != "query":
+        emit({"type": "error", "error": f"unknown mode: {mode!r} (expected query|watch)"})
+        return 1
+    return run_query(target)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## New Recipe: transcript_completion

**Type:** atomic
**Runtime:** python
**Version:** 1.0.0

### Description

解析 Claude Code session JSONL，用权威 stop_reason 判定最新一轮是否答完并抽取该轮 assistant 最终文本。query 一次性查询 / watch 长驻事件式上报，watch 形态可由 daemon supervisor 托管

### Use Cases

- query：给定 session_id+cwd 或 path，同步判定 transcript 尾部最新一轮是否完成 + 取最终文本（供 tmux 完成判定采信权威信号而非读屏）
- watch：watchdog 盯单个 jsonl，检测到一轮完成翻转时向 stdout 打一行 turn_complete 事件，供 daemon supervisor 流式消费
- 冻结恢复：拿到 session id → locate_transcript 定位文件 → 解析尾部

---

*Submitted via `frago recipe share`*
