### PR TITLE
feat(recipe): add wechat_draft_create recipe

### DIFF
--- a/community-recipes/recipes/wechat_draft_create/common.py
+++ b/community-recipes/recipes/wechat_draft_create/common.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""wechat_draft_create 共享浏览器管线：browser 调用、exec-js、等待、登录、保存。
+
+文章和贴图两种编辑器的驱动都依赖这里的原语。改动会同时影响两条链路。
+"""
+
+import json
+import re
+import subprocess
+import sys
+import time
+
+HOME_URL = "https://mp.weixin.qq.com/"
+
+# 等条件的上限，单位秒。轮询间隔统一 0.5 秒。
+TIMEOUT_HOME = 20
+TIMEOUT_EDITOR = 30
+TIMEOUT_READY = 30
+TIMEOUT_SET = 20
+# 点「保存为草稿」后页面先跑「自检中」（错别字自检），这段时间一个请求都不发。
+# 实测冷页面能占到 20 秒左右，所以等提交请求发出的上限给到 120 秒。
+TIMEOUT_SAVE_SUBMIT = 120
+# 提交请求发出后等它回包。
+TIMEOUT_SAVE_RESP = 60
+# 保存落库后等地址里带出草稿 ID（新建才需要，更新时地址本来就有）。
+TIMEOUT_SAVE_ID = 20
+POLL = 0.5
+
+WARNINGS = []
+
+# 浏览器扩展桥只对当前活动的标签页求值，对非活动标签页会一直挂住不返回。
+# 别的标签页一抢焦点，本配方的求值就全卡死。这里记住自己的标签页，必要时切回来。
+_TAB_ID = None
+_ALWAYS_ACTIVATE = False
+EJS_TIMEOUT = 20
+
+
+def log(msg):
+    print(msg, file=sys.stderr)
+
+
+def die(msg, hint=""):
+    out = {"success": False, "error": msg}
+    if hint:
+        out["hint"] = hint
+    print(json.dumps(out, ensure_ascii=False))
+    print(msg + (("\n" + hint) if hint else ""), file=sys.stderr)
+    sys.exit(1)
+
+
+def die_logged_out(where):
+    die(f"公众号后台登录态失效（{where}）",
+        "请在浏览器里打开 https://mp.weixin.qq.com 重新扫码登录，然后重跑本配方。")
+
+
+def browser(args, timeout=120):
+    """调 frago browser，返回 (成功与否, 解析后的 JSON 或原始文本)。超时返回 (None, None)。"""
+    try:
+        r = subprocess.run(["frago", "browser"] + args,
+                           capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        return None, None
+    raw = (r.stdout or "").strip()
+    if not raw:
+        return False, (r.stderr or "").strip()
+    try:
+        return r.returncode == 0, json.loads(raw)
+    except json.JSONDecodeError:
+        return r.returncode == 0, raw
+
+
+def navigate(url, group):
+    global _TAB_ID
+    ok, res = browser(["navigate", url, "--group", group])
+    if not ok:
+        die(f"导航失败：{url}", str(res)[:300])
+    if isinstance(res, dict) and res.get("tab_id"):
+        _TAB_ID = res["tab_id"]
+    return res
+
+
+def activate():
+    """把自己的标签页切回前台。扩展桥只服务活动标签页。"""
+    if _TAB_ID:
+        browser(["switch-tab", str(_TAB_ID)], timeout=20)
+
+
+def ejs(code, group, timeout=EJS_TIMEOUT):
+    """在页面里求值。code 必须自带 IIFE 包裹——exec-js 多次执行共享页面全局作用域，
+    裸的 const 声明第二次就会撞名。
+
+    标签页不在前台时求值会挂住，所以超时后切回前台重试一次；一旦发生过，
+    之后每次求值都先切，免得每一轮都白等一个超时。"""
+    global _ALWAYS_ACTIVATE
+    if _ALWAYS_ACTIVATE:
+        activate()
+    ok, res = browser(["exec-js", "--group", group, code, "--return-value"], timeout=timeout)
+    if ok is None:
+        activate()
+        _ALWAYS_ACTIVATE = True
+        ok, res = browser(["exec-js", "--group", group, code, "--return-value"], timeout=timeout)
+        if ok is None:
+            die("在页面里求值超时两次",
+                "标签页可能已被关闭，或者浏览器扩展桥失联。先跑 frago browser status 看看。")
+    if not ok:
+        return None
+    if isinstance(res, dict):
+        return res.get("value")
+    return res
+
+
+def ejs_json(code, group, timeout=EJS_TIMEOUT):
+    v = ejs(code, group, timeout)
+    if not isinstance(v, str):
+        return v
+    try:
+        return json.loads(v)
+    except json.JSONDecodeError:
+        return v
+
+
+def wait_for(probe, limit, desc, group):
+    """轮询到 probe 返回真值为止。超时报错时带上当时的地址，便于人判断卡在哪。"""
+    deadline = time.time() + limit
+    last = None
+    while time.time() < deadline:
+        last = probe()
+        if last:
+            return last
+        time.sleep(POLL)
+    here = ejs("(()=>location.href)()", group) or "地址读不到"
+    die(f"等待超时：{desc}（上限 {limit} 秒）", f"当时的地址：{here}")
+
+
+def current_url(group):
+    return ejs("(()=>location.href)()", group) or ""
+
+
+def get_token(group):
+    """登录态有效时后台首页会重定向到带 token 的地址。取不到就是没登录。"""
+    log("[1/8] 取后台 token")
+    navigate(HOME_URL, group)
+
+    deadline = time.time() + TIMEOUT_HOME
+    token = None
+    while time.time() < deadline:
+        u = current_url(group)
+        if u:
+            if "/login" in u or "action=login" in u:
+                die_logged_out("后台首页跳到了登录页")
+            m = re.search(r"[?&]token=(\d+)", u)
+            if m:
+                token = m.group(1)
+                break
+        time.sleep(POLL)
+    if not token:
+        # 登录态有效时根路径必然重定向到带 token 的地址；等不到就是没登录。
+        die_logged_out(f"{TIMEOUT_HOME} 秒内地址里没出现 token")
+    log(f"    token={token}")
+    return token
+
+
+# 点保存前装的提交监听。
+#
+# 认「提交」不认地址：真正带着内容上行的那一发，请求体里必有 title0=。它落在哪个接口
+# 不固定——错别字自检没开时直接走 /cgi-bin/operate_appmsg?sub=update，开着自检时整份
+# 内容改由 /publicpoc/selfcheck?action=check 带上去（实测两种都能落库）。所以只认请求体，
+# 不认 URL。自检的 pre_load_sentence 带的是 title= 不是 title0=，不会误判。
+#
+# 认「落库」看 get_appmsg_update_history：保存成功后页面会去刷「历史版本」，两条路径都刷。
+_SAVE_WATCH = r"""(()=>{
+if(window.__fragoSaveWatch){
+  const s=window.__fragoSaveWatch;
+  s.sent=false;s.title=null;s.ret=null;s.resp='';s.saved=false;
+  return 'reset';
+}
+const st={sent:false,title:null,ret:null,resp:'',saved:false};
+const XO=XMLHttpRequest.prototype.open, XS=XMLHttpRequest.prototype.send;
+XMLHttpRequest.prototype.open=function(m,u){this.__fragoUrl=u;return XO.apply(this,arguments)};
+XMLHttpRequest.prototype.send=function(b){
+  try{
+    const u=String(this.__fragoUrl||'');
+    const s=(typeof b==='string')?b:'';
+    const m=/(?:^|&)title0=([^&]*)/.exec(s);
+    const x=this;
+    if(m){
+      st.sent=true;
+      st.title=decodeURIComponent(m[1].replace(/\+/g,' '));
+      x.addEventListener('loadend',function(){
+        let j=null;try{j=JSON.parse(x.responseText)}catch(e){}
+        st.ret=(j&&j.base_resp)?j.base_resp.ret:(x.status===200?0:-1);
+        st.resp=String(x.responseText||'').slice(0,300);
+      });
+    }else if(u.indexOf('get_appmsg_update_history')>=0){
+      x.addEventListener('loadend',function(){st.saved=true});
+    }
+  }catch(e){}
+  return XS.apply(this,arguments);
+};
+window.__fragoSaveWatch=st;
+return 'installed';
+})()"""
+
+
+def _save_watch(group):
+    """读提交监听的当前状态。返回 None 表示监听不在了——页面重载过。"""
+    r = ejs_json("(()=>JSON.stringify(window.__fragoSaveWatch||null))()", group)
+    return r if isinstance(r, dict) else None
+
+
+def click_save(group):
+    """点「保存为草稿」，等提交请求真正落库，再取草稿 ID。两种编辑器共用。
+
+    别拿「地址里有 appmsgid」当保存完成的信号：更新已有草稿时地址一开始就带着
+    appmsgid，那个判断立刻为真，调用方会在保存还没发出去时就导航走，把这一发掐掉。
+    点击到提交之间隔着页面的「自检中」（错别字自检），实测能有二十秒。
+    """
+    log("[7/8] 点保存为草稿")
+    before = current_url(group)
+    had_id = bool(re.search(r"[?&]appmsgid=(\d+)", before))
+    if ejs(_SAVE_WATCH, group) is None:
+        die("装不上保存提交监听", "页面可能已失效，先跑 frago browser status 看看。")
+    code = """(()=>{
+const b=Array.from(document.querySelectorAll('button,.weui-desktop-btn,a'))
+  .find(x=>x.innerText.trim()==='保存为草稿');
+if(!b)return 'no-button';
+const r=b.getBoundingClientRect();
+const o={bubbles:true,cancelable:true,view:window,
+         clientX:r.left+r.width/2,clientY:r.top+r.height/2};
+['pointerdown','mousedown','pointerup','mouseup','click'].forEach(n=>
+  b.dispatchEvent(n.startsWith('pointer')?new PointerEvent(n,o):new MouseEvent(n,o)));
+return 'clicked';
+})()"""
+    if ejs(code, group) != "clicked":
+        die("页面上找不到「保存为草稿」按钮",
+            "公众号后台可能改版了，按钮文案变了。手动打开编辑器看一眼实际文案。")
+
+    def submitted():
+        u = current_url(group)
+        if "/login" in u:
+            die_logged_out("保存时跳到了登录页")
+        st = _save_watch(group)
+        if st is None:
+            # 监听没了 = 页面重载过。重载只会发生在保存落库之后，按已提交处理。
+            return {"reloaded": True}
+        return st if st.get("sent") else None
+
+    log("    等页面跑完错别字自检、把内容提交上去")
+    st = wait_for(submitted, TIMEOUT_SAVE_SUBMIT,
+                  "保存请求发出（页面卡在「自检中」超时）", group)
+
+    if not st.get("reloaded"):
+        log(f"    已提交，请求体里的标题是「{st.get('title')}」")
+
+        def landed():
+            cur = _save_watch(group)
+            if cur is None:
+                return {"reloaded": True}
+            if cur.get("ret") not in (None, 0):
+                die(f"后台没接受这次保存（ret={cur.get('ret')}）",
+                    f"后台回的是：{cur.get('resp')}")
+            return cur if cur.get("saved") else None
+
+        st = wait_for(landed, TIMEOUT_SAVE_RESP, "保存落库（页面刷新历史版本）", group)
+
+    def has_id():
+        u = current_url(group)
+        if "/login" in u:
+            die_logged_out("保存后跳到了登录页")
+        m = re.search(r"[?&]appmsgid=(\d+)", u)
+        return m.group(1) if m else None
+
+    if had_id:
+        appmsgid = has_id()
+        if not appmsgid:
+            die("保存后地址里的草稿 ID 不见了", f"当时的地址：{current_url(group)}")
+    else:
+        appmsgid = wait_for(has_id, TIMEOUT_SAVE_ID, "保存后地址带出草稿 ID", group)
+    return appmsgid, before

--- a/community-recipes/recipes/wechat_draft_create/editors/__init__.py
+++ b/community-recipes/recipes/wechat_draft_create/editors/__init__.py
@@ -1,0 +1,1 @@
+"""wechat_draft_create 的内容类型驱动包：文章（article）与贴图（poster）。"""

--- a/community-recipes/recipes/wechat_draft_create/editors/article.py
+++ b/community-recipes/recipes/wechat_draft_create/editors/article.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""文章（图文，type=10/createType 无）编辑器驱动。
+
+把排好版的 HTML 送进标准图文编辑器：官方桥 window.__MP_Editor_JSAPI__ 的
+mp_editor_set_content 设全文，行内样式一个不掉。
+"""
+
+import json
+import time
+
+from common import (WARNINGS, POLL, TIMEOUT_EDITOR, TIMEOUT_READY, TIMEOUT_SET,
+                    die, die_logged_out, ejs, ejs_json, navigate, wait_for, log)
+
+EDITOR_NEW = ("https://mp.weixin.qq.com/cgi-bin/appmsg?t=media/appmsg_edit_v2"
+              "&action=edit&isNew=1&type=10&token={token}&lang=zh_CN")
+EDITOR_EDIT = ("https://mp.weixin.qq.com/cgi-bin/appmsg?t=media/appmsg_edit_v2"
+               "&action=edit&type=77&appmsgid={appmsgid}&token={token}&lang=zh_CN")
+
+TITLE_MAX = 64
+AUTHOR_MAX = 8
+
+# 动作之间的间隔。编辑器有自己的防抖和自动保存，抢太快会丢内容。
+GAP_AFTER_TITLE = 1.0
+GAP_AFTER_CONTENT = 2.0
+
+TYPE = "article"
+
+
+def current_url(group):
+    return ejs("(()=>location.href)()", group) or ""
+
+
+def open_editor(token, group, appmsgid=None):
+    if appmsgid:
+        url = EDITOR_EDIT.format(appmsgid=appmsgid, token=token)
+        log("[2/8] 打开已有草稿 appmsgid={appmsgid}".format(appmsgid=appmsgid))
+    else:
+        url = EDITOR_NEW.format(token=token)
+        log("[2/8] 打开新建编辑器")
+    navigate(url, group)
+
+    def probe():
+        u = current_url(group)
+        if "/login" in u:
+            die_logged_out("编辑器页跳到了登录页")
+        return ejs("(()=>!!document.querySelector('#title'))()", group) is True
+
+    wait_for(probe, TIMEOUT_EDITOR, "编辑器页出现标题输入框", group)
+
+
+def wait_editor_ready(group):
+    log("[3/8] 等编辑器就绪")
+    has_bridge = ejs("(()=>!!window.__MP_Editor_JSAPI__)()", group)
+    if has_bridge is not True:
+        die("编辑器页面上没有官方桥 __MP_Editor_JSAPI__",
+            "可能是页面没加载完、公众号改版、或者登录态失效。先在浏览器里手动打开一次编辑器确认。")
+
+    def probe():
+        ejs("(()=>{window.__fr=window.__fr||{};"
+            "window.__MP_Editor_JSAPI__.invoke({apiName:'mp_editor_get_isready',"
+            "sucCb:r=>window.__fr.ready=r,errCb:e=>window.__fr.ready={err:1}});"
+            "return 'sent'})()", group)
+        time.sleep(POLL)
+        r = ejs_json("(()=>JSON.stringify(window.__fr&&window.__fr.ready||null))()", group)
+        if isinstance(r, dict) and r.get("isReady"):
+            if not r.get("isNew"):
+                WARNINGS.append("编辑器回报 isNew=false，设置全文内容的接口可能不可用")
+            return True
+        return False
+
+    wait_for(probe, TIMEOUT_READY, "编辑器回报已就绪", group)
+
+
+def set_title(title, author, group):
+    log(f"[4/8] 设标题（{len(title)} 字）")
+    code = """(()=>{
+const t=document.querySelector('#title');
+if(!t)return 'no-title';
+t.focus();
+const s=Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype,'value').set;
+s.call(t,%s);
+t.dispatchEvent(new Event('input',{bubbles:true}));
+t.dispatchEvent(new Event('change',{bubbles:true}));
+let au='';
+if(%s){
+  const a=document.querySelector('#author');
+  if(a){a.focus();
+    const s2=Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype,'value').set;
+    s2.call(a,%s);a.dispatchEvent(new Event('input',{bubbles:true}));au=a.value;}
+}
+return JSON.stringify({title:t.value,author:au});
+})()""" % (json.dumps(title), json.dumps(bool(author)), json.dumps(author or ""))
+    r = ejs_json(code, group)
+    if not isinstance(r, dict) or r.get("title") != title:
+        die("标题没能写进编辑器", f"编辑器里现在是：{r}")
+    if author and not r.get("author"):
+        WARNINGS.append("作者字段没找到输入框，已跳过")
+    time.sleep(GAP_AFTER_TITLE)
+
+
+def set_content(html, group):
+    log(f"[5/8] 设正文（{len(html)} 字符）")
+    code = """(()=>{
+window.__fr=window.__fr||{};window.__fr.set=null;
+window.__MP_Editor_JSAPI__.invoke({
+  apiName:'mp_editor_set_content',
+  apiParam:{content:%s},
+  sucCb:r=>window.__fr.set=r||{msg:'ok'},
+  errCb:e=>window.__fr.set={err:String(e&&e.msg||e)}
+});
+return 'sent';
+})()""" % json.dumps(html)
+    if ejs(code, group) is None:
+        die("调用设置全文内容的接口失败", "HTML 可能过大导致传参被截断，或者页面已失效。")
+
+    def probe():
+        r = ejs_json("(()=>JSON.stringify(window.__fr&&window.__fr.set||null))()", group)
+        if isinstance(r, dict) and r.get("err"):
+            die("编辑器拒绝了这份内容", str(r.get("err"))[:300])
+        return isinstance(r, dict)
+
+    wait_for(probe, TIMEOUT_SET, "编辑器回报内容已设置", group)
+    time.sleep(GAP_AFTER_CONTENT)
+
+
+def set_cover(cover_path, group):
+    """上传封面图并设到草稿上。两条链路：upload_material 上素材库拿 cdn_url，
+    再调官方桥 mp_editor_change_cover({oriImgUrl})。scene=2 实测有效。"""
+    log("[5/8] 设封面（%s）" % cover_path)
+    import os
+    import base64 as _b64
+    if not os.path.isfile(cover_path):
+        die(f"封面图片文件不存在：{cover_path}")
+    try:
+        with open(cover_path, "rb") as f:
+            data = f.read()
+    except OSError as e:
+        die(f"读封面图片失败：{cover_path}：{e}")
+    if len(data) > 700_000:
+        die(f"封面图片 {len(data)} 字节，超过约 700KB 上限",
+            "exec-js 命令行装不下太大的 base64，压缩后再试。")
+    b64 = _b64.b64encode(data).decode()
+    code = """(()=>{
+window.__fr=window.__fr||{};window.__fr.cov={state:'start'};
+const b64=%s;
+const bin=atob(b64);const arr=new Uint8Array(bin.length);
+for(let i=0;i<bin.length;i++)arr[i]=bin.charCodeAt(i);
+const file=new File([arr],'cover.png',{type:'image/png'});
+const fd=new FormData();
+fd.append('file',file,'cover.png');
+const url=wx.url('/cgi-bin/filetransfer?action=upload_material&f=json&scene=2'
+  +'&writetype=doublewrite&groupid=1&ticket_id='+wx.data.user_name
+  +'&ticket='+wx.data.ticket+'&svr_time='+wx.data.time);
+window.__fr.cov.state='uploading';
+fetch(url,{method:'POST',body:fd,credentials:'same-origin'})
+ .then(function(r){return r.json()})
+ .then(function(j){
+   const ret=j&&j.base_resp?j.base_resp.ret:-1;
+   if(ret!==0){window.__fr.cov={state:'up-error',ret:ret,resp:JSON.stringify(j).slice(0,200)};return}
+   window.__fr.cov.cdn=j.cdn_url;
+   window.__fr.cov.state='setting';
+   window.__MP_Editor_JSAPI__.invoke({
+     apiName:'mp_editor_change_cover',
+     apiParam:{oriImgUrl:j.cdn_url},
+     sucCb:function(r){window.__fr.cov={state:'done',msg:(r&&r.msg)||'ok'}},
+     errCb:function(e){window.__fr.cov={state:'set-error',err:String(e&&e.msg||e)}}
+   });
+ })
+ .catch(function(e){window.__fr.cov={state:'err',err:String(e)}});
+return 'started';
+})()""" % json.dumps(b64)
+    if ejs(code, group) is None:
+        die("封面脚本没跑起来", "图片注入失败，页面可能已失效。")
+
+    deadline = time.time() + 60
+    last = None
+    while time.time() < deadline:
+        time.sleep(1.0)
+        last = ejs_json("(()=>JSON.stringify(window.__fr&&window.__fr.cov||null))()", group)
+        if not isinstance(last, dict):
+            continue
+        if last.get("state") in ("up-error", "set-error", "err"):
+            die(f"封面设置失败（{last.get('state')}）：{last.get('err') or last.get('resp') or last.get('ret')}",
+                "上传素材库可能频控或登录态失效。")
+        if last.get("state") == "done":
+            log(f"    封面已设置（{last.get('msg')}）")
+            return
+    die("封面设置超时", f"最后状态：{last}")
+
+
+def cover_set(group):
+    """重开草稿后检查封面是否在：封面预览/侧栏缩略图带 mmbiz 背景图就算在。"""
+    r = ejs_json("""(()=>{const els=Array.from(document.querySelectorAll(
+'.js_cover_preview_new,.card_appmsg_thumb,.js_cover_preview,select-cover__preview'));
+let hit=false;
+for(const el of els){const bg=getComputedStyle(el).backgroundImage;
+  if(bg.indexOf('mmbiz')>=0){hit=true;break}}
+return JSON.stringify({hit})})()""", group)
+    return isinstance(r, dict) and r.get("hit") is True
+
+
+def read_content(group):
+    """用官方接口读全文。NEVER 去读 .ProseMirror 容器的 innerHTML——那不是正文区。"""
+    ejs("(()=>{window.__fr=window.__fr||{};window.__fr.got=null;"
+        "window.__MP_Editor_JSAPI__.invoke({apiName:'mp_editor_get_content',"
+        "sucCb:r=>window.__fr.got=r,errCb:e=>window.__fr.got={err:1}});return 'sent'})()", group)
+    deadline = time.time() + TIMEOUT_SET
+    while time.time() < deadline:
+        time.sleep(POLL)
+        r = ejs_json("(()=>{const g=window.__fr&&window.__fr.got;if(!g)return 'null';"
+                     "const c=g.content||'';return JSON.stringify({len:c.length,"
+                     "styles:(c.match(/style=/g)||[]).length,"
+                     "tables:(c.match(/<table/g)||[]).length,"
+                     "images:(c.match(/<img/g)||[]).length})})()", group)
+        if isinstance(r, dict):
+            return r
+    return None
+
+
+def precheck(sent_len, group):
+    """点保存之前先确认内容真的进去了。空的就报错——点了就是一篇空草稿留在人家草稿箱。"""
+    log("[6/8] 存前自检")
+    got = read_content(group)
+    if not got:
+        die("存前自检读不回内容", "不点保存，避免在草稿箱留下空文章。")
+    if got["len"] < sent_len * 0.5:
+        die(f"存前自检不通过：送进去 {sent_len} 字符，编辑器里只有 {got['len']} 字符",
+            "不点保存，避免在草稿箱留下残缺文章。")
+    log(f"    编辑器里 {got['len']} 字符 / {got['styles']} 处行内样式")
+    return got
+
+
+def verify_stored(token, appmsgid, sent, group):
+    log("[8/8] 重开草稿回读校验")
+    navigate(EDITOR_EDIT.format(appmsgid=appmsgid, token=token), group)
+
+    def probe():
+        return ejs("(()=>!!(document.querySelector('#title')&&window.__MP_Editor_JSAPI__))()",
+                   group) is True
+
+    wait_for(probe, TIMEOUT_EDITOR, "草稿重新打开", group)
+    got = read_content(group)
+    if not got:
+        WARNINGS.append("回读校验没读到内容，草稿可能已建成但内容存疑，请人工打开确认")
+        return {"len": 0, "styles": 0, "tables": 0, "images": 0}
+
+    # 服务器会剥掉根容器的 id、给文字节点包上自己的标记，字符数略有出入属正常。
+    if sent["styles"] and got["styles"] < sent["styles"] * 0.5:
+        die(f"回读校验不通过：送进去 {sent['styles']} 处行内样式，草稿里只剩 {got['styles']} 处",
+            f"草稿已建成（ID {appmsgid}），但排版没保住，请人工打开确认。")
+    # 服务器会做归一化（合并等价声明、剥掉根容器的 id），行内样式数差个一两处属正常，
+    # 差 5% 以上才值得提醒。表格和图片是结构性的，少一个就该说。
+    if abs(got["styles"] - sent["styles"]) > max(2, sent["styles"] * 0.05):
+        WARNINGS.append(f"行内样式数量对不上：送进去 {sent['styles']}，草稿里 {got['styles']}")
+    for key, label in (("tables", "表格"), ("images", "图片")):
+        if got[key] != sent[key]:
+            WARNINGS.append(f"{label}数量对不上：送进去 {sent[key]}，草稿里 {got[key]}")
+    if sent.get("cover"):
+        if cover_set(group):
+            log("    封面在")
+        else:
+            die(f"回读校验不通过：封面没保住",
+                f"草稿已建成（ID {appmsgid}），封面区仍是空的，请人工打开确认。")
+    log(f"    草稿里 {got['len']} 字符 / {got['styles']} 处行内样式 / "
+        f"{got['tables']} 个表格 / {got['images']} 张图")
+    return got

--- a/community-recipes/recipes/wechat_draft_create/editors/poster.py
+++ b/community-recipes/recipes/wechat_draft_create/editors/poster.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+"""贴图（image post，createType=8）编辑器驱动。
+
+贴图编辑器形态：标题是 contenteditable 的 ProseMirror（上限 20 字），描述是另一个
+ProseMirror（上限 1000 字），主图区是 `.image-selector` Vue 组件。保存按钮与文章共用
+「保存为草稿」，跳转后 URL 带 appmsgid。
+
+图片上传走两条门（见 wechat-writing/mp-tietu-image-upload-path）：
+  1. 上游 POST /cgi-bin/filetransfer?action=upload_material 上素材库（普通 multipart）
+  2. 下游把结果按 WebUploader 事件语义喂给 `.image-selector` 的公开方法
+     uploadSelect → uploadComplete → uploadAllComplete，组件自己补 seq/宽高/选中。
+"""
+
+import json
+import os
+import time
+
+from common import (WARNINGS, POLL, TIMEOUT_EDITOR, TIMEOUT_READY, TIMEOUT_SET,
+                    die, die_logged_out, ejs, ejs_json, navigate, wait_for, log)
+
+POSTER_NEW = ("https://mp.weixin.qq.com/cgi-bin/appmsg?t=media/appmsg_edit_v2"
+              "&action=edit&isNew=1&type=10&createType=8&token={token}&lang=zh_CN")
+EDITOR_EDIT = ("https://mp.weixin.qq.com/cgi-bin/appmsg?t=media/appmsg_edit_v2"
+               "&action=edit&type=77&appmsgid={appmsgid}&token={token}&lang=zh_CN")
+
+TITLE_MAX = 20
+DESC_MAX = 1000
+IMG_MAX = 20
+
+# 图片 base64 全量塞进一次 exec-js 参数。ARG_MAX 上限 1MB（macOS），留余量给其他参数和 env。
+# 超过这个量直接报错，不静默截断。
+B64_ARG_LIMIT = 500_000
+
+# 上传完成（含 formatList 补宽高）需要的时间，单位秒。
+WAIT_AFTER_UPLOAD_ALL = 1.5
+
+# 上传图片时同一编辑会话内的间隔，避开后台频控（ret=200013）。
+GAP_BETWEEN_UPLOADS = 0.8
+
+TYPE = "poster"
+
+# 页面内注入的上传器：上传素材库 + 喂给 Vue 组件，定义 window.__fragoTietu.addImages。
+# 与 worker 2026-08-06 验证过的 tietu-image-upload.js 一致。
+_INJECTOR = r"""function() {
+  function b64ToFile(b64, name, type) {
+    var bin = atob(b64);
+    var arr = new Uint8Array(bin.length);
+    for (var i = 0; i < bin.length; i++) arr[i] = bin.charCodeAt(i);
+    return new File([arr], name, { type: type || 'image/png' });
+  }
+  function vmOf() {
+    var el = document.querySelector('#js_content_top .image-selector') ||
+             document.querySelector('.image-selector');
+    if (!el || !el.__vue__) throw new Error('image-selector Vue 实例找不到');
+    return el.__vue__;
+  }
+  function uploadUrl(vm) {
+    var q = vm.uploadQuery || { scene: 5, writetype: 'doublewrite', groupid: 1 };
+    return wx.url('/cgi-bin/filetransfer?action=upload_material&f=json' +
+      '&scene=' + q.scene + '&writetype=' + q.writetype + '&groupid=' + q.groupid +
+      '&ticket_id=' + wx.data.user_name + '&ticket=' + wx.data.ticket +
+      '&svr_time=' + wx.data.time);
+  }
+  function readSize(file) {
+    return new Promise(function (resolve) {
+      var url = URL.createObjectURL(file);
+      var img = new Image();
+      img.onload = function () { URL.revokeObjectURL(url); resolve({ width: img.naturalWidth, height: img.naturalHeight }); };
+      img.onerror = function () { URL.revokeObjectURL(url); resolve({ width: 0, height: 0 }); };
+      img.src = url;
+    });
+  }
+  function uploadOne(vm, file) {
+    var fd = new FormData();
+    fd.append('file', file, file.name);
+    return fetch(uploadUrl(vm), { method: 'POST', body: fd, credentials: 'same-origin' })
+      .then(function (r) { return r.json(); })
+      .then(function (j) {
+        var ret = j && j.base_resp ? j.base_resp.ret : -1;
+        if (ret !== 0) throw new Error('upload_material ret=' + ret + ' ' + JSON.stringify(j).slice(0,200));
+        return j;
+      });
+  }
+  function addImages(items) {
+    var api = window.__fragoTietu;
+    api.result = { state: 'running', uploaded: [], error: null };
+    var vm;
+    try { vm = vmOf(); } catch (e) { api.result = { state: 'error', error: '' + e }; return; }
+    // 替换语义：传了图就先清空现有图片，再传新的。更新草稿时旧图不会残留成重复。
+    // 不带图更新（只改文字）不会走到这里，旧图保留。
+    vm.innerList = [];
+    vm.selected = null;
+    if (items.length > 20) {
+      api.result = { state: 'error', error: '超过 20 张上限' };
+      return;
+    }
+    var chain = Promise.resolve();
+    items.forEach(function (it, idx) {
+      chain = chain.then(function () {
+        var file = b64ToFile(it.b64, it.name || ('img' + idx + '.png'), it.type);
+        return readSize(file).then(function (sz) {
+          return uploadOne(vm, file).then(function (resp) {
+            var tmpId = 'FRAGO_' + idx + '_' + file.size;
+            vm.uploadSelect({ id: tmpId, size: file.size,
+              extension: (file.name.split('.').pop() || 'png').toLowerCase(),
+              width: sz.width, height: sz.height });
+            vm.uploadComplete({ id: tmpId }, { content: resp.content, cdn_url: resp.cdn_url });
+            api.result.uploaded.push({ file_id: resp.content, cdn_url: resp.cdn_url, w: sz.width, h: sz.height });
+          });
+        });
+      });
+    });
+    chain.then(function () {
+      vm.uploadAllComplete();
+      return new Promise(function (r) { setTimeout(r, 1500); });
+    }).then(function () {
+      api.result.state = 'done';
+      api.result.innerList = vm.innerList.map(function (x) {
+        return { file_id: x.file_id, seq: x.seq, loading: x.loading, width: x.width, height: x.height };
+      });
+      api.result.selected = vm.selected;
+    }).catch(function (e) {
+      api.result.state = 'error';
+      api.result.error = '' + (e && e.message ? e.message : e);
+    });
+  }
+  window.__fragoTietu = { addImages: addImages, result: null };
+  return 'ready';
+}"""
+
+
+# 取编辑器组件本体的办法：给元素和想要的方法名，返回真正带这个方法的那个组件。
+#
+# 认方法不认层级，是因为层级不稳定：`.title-editor-overlay` 上挂的 __vue__ 不一定是
+# mp-title-editor——外层匿名包装组件和它共用同一个根元素，__vue__ 谁后挂载谁写上去。
+# 实测编辑已有草稿时拿到的是本体，新建时拿到的是外层包装，后者没有 getView，直接调
+# 就报「不是函数」。
+# 描述那边则是读写本来就分家：写要 getView（在里层 MpEditor 上），读要 getContent
+# （在外层 mp-common-share-editor 上），同一个元素取不到两样东西。
+_VM = """function(sel,m){
+  const el=document.querySelector(sel);
+  if(!el||!el.__vue__)return null;
+  let v=el.__vue__;
+  for(let i=0;i<5&&v&&typeof v[m]!=='function';i++)v=v.$refs&&v.$refs.editor;
+  return (v&&typeof v[m]==='function')?v:null;
+}"""
+TITLE_SEL = "#js_title_main .title-editor-overlay"
+DESC_SEL = ".share-text__area"        # 写：里层 MpEditor，有 getView
+DESC_READ_SEL = "#guide_words_main"   # 读：外层 mp-common-share-editor，有 getContent
+
+# 组件挂载完成的判据：本体拿得到，且它已经能交出 ProseMirror view。
+_MOUNTED = ("(()=>{const vmOf=(%s);const v=vmOf(%%s,'getView');"
+            "if(!v)return false;try{return !!v.getView()}catch(e){return false}})()" % _VM)
+
+
+def current_url(group):
+    return ejs("(()=>location.href)()", group) or ""
+
+
+def open_editor(token, group, appmsgid=None):
+    if appmsgid:
+        url = EDITOR_EDIT.format(appmsgid=appmsgid, token=token)
+        log("[2/8] 打开已有贴图草稿 appmsgid={appmsgid}".format(appmsgid=appmsgid))
+    else:
+        url = POSTER_NEW.format(token=token)
+        log("[2/8] 打开新建贴图编辑器")
+    navigate(url, group)
+
+    # 光看到 .ProseMirror 还不算就绪：标题编辑器的 Vue 组件（往后所有写入都经它）
+    # 挂载得比裸 DOM 晚，新建页尤其明显。等到组件挂上、且能拿出 view 才算数。
+    def probe():
+        u = current_url(group)
+        if "/login" in u:
+            die_logged_out("编辑器页跳到了登录页")
+        return ejs(_MOUNTED % json.dumps(TITLE_SEL), group) is True
+
+    wait_for(probe, TIMEOUT_EDITOR, "贴图编辑器的标题组件挂载完成", group)
+
+
+def wait_editor_ready(group):
+    log("[3/8] 等贴图编辑器就绪")
+    has_bridge = ejs("(()=>!!window.__MP_Editor_JSAPI__)()", group)
+    if has_bridge is not True:
+        die("贴图编辑器页面上没有官方桥 __MP_Editor_JSAPI__",
+            "可能是页面没加载完、公众号改版、或者登录态失效。先手动打开一次贴图编辑器确认。")
+
+    def probe():
+        ejs("(()=>{window.__fr=window.__fr||{};"
+            "window.__MP_Editor_JSAPI__.invoke({apiName:'mp_editor_get_isready',"
+            "sucCb:r=>window.__fr.ready=r,errCb:e=>window.__fr.ready={err:1}});"
+            "return 'sent'})()", group)
+        time.sleep(POLL)
+        r = ejs_json("(()=>JSON.stringify(window.__fr&&window.__fr.ready||null))()", group)
+        return isinstance(r, dict) and r.get("isReady") is True
+
+    wait_for(probe, TIMEOUT_READY, "贴图编辑器回报已就绪", group)
+
+
+def set_title(title, group):
+    """标题分两步写进 mp-title-editor，两步都要，缺一个都会在更新草稿时出问题。
+
+    保存时页面调的是组件的 getContent()，它实时序列化 ProseMirror view 的文档——
+    view 才是权威。隐藏域 textarea#title 只是镜像（实测：把镜像改成别的字，
+    提交上去的仍是 view 里的字），execCommand 只改 DOM 更是白改。
+
+    但只 dispatch 也不够：组件 data 里的 currentContent 是渲染 ProseMirror 的数据源，
+    dispatch 不会更新它。它一直停在打开草稿时的旧标题上，一旦组件重渲染就会把旧标题
+    灌回 view。所以先 setContent 把 currentContent 对齐，再 dispatch 把 view 对齐
+    并触发 input 事件同步镜像和字数统计。
+    """
+    log(f"[4/8] 设贴图标题（{len(title)} 字）")
+    seed = """(()=>{
+const v=(%s)(%s,'setContent');
+if(!v)return JSON.stringify({ok:false,why:'no-component'});
+v.setContent(%s);
+return JSON.stringify({ok:true});
+})()""" % (_VM, json.dumps(TITLE_SEL), json.dumps(title))
+    r = ejs_json(seed, group)
+    if not isinstance(r, dict) or not r.get("ok"):
+        die("标题编辑器没找到", f"编辑器里现在是：{r}")
+    time.sleep(POLL)
+
+    code = """(()=>{
+const v=(%s)(%s,'getView');
+if(!v)return JSON.stringify({ok:false,why:'no-component'});
+const view=v.getView();
+if(!view)return JSON.stringify({ok:false,why:'no-view'});
+const st=view.state;
+view.dispatch(st.tr.insertText(%s,0,st.doc.content.size));
+return JSON.stringify({ok:true});
+})()""" % (_VM, json.dumps(TITLE_SEL), json.dumps(title))
+    r = ejs_json(code, group)
+    if not isinstance(r, dict) or not r.get("ok"):
+        die("标题编辑器的 ProseMirror view 拿不到", f"编辑器里现在是：{r}")
+
+    check = """(()=>{
+const v=(%s)(%s,'getContent');
+if(!v)return JSON.stringify({});
+let g='';try{g=v.getContent()||''}catch(e){}
+const ta=(document.querySelector('textarea#title')||{}).value||'';
+return JSON.stringify({g:g.trim(),c:(v.currentPlainContent||'').trim(),ta:ta.trim()});
+})()""" % (_VM, json.dumps(TITLE_SEL))
+
+    def probe():
+        rr = ejs_json(check, group)
+        return (isinstance(rr, dict) and rr.get("g") == title
+                and rr.get("c") == title and rr.get("ta") == title)
+
+    wait_for(probe, TIMEOUT_SET, "标题写入并同步（view/组件数据/隐藏域三处一致）", group)
+    time.sleep(0.5)
+
+
+def set_description(desc, group):
+    """描述走 MpEditor.getView() 的官方事务 API。execCommand 同样只改 DOM，更新时丢内容。"""
+    log(f"[5/8] 设贴图描述（{len(desc)} 字）")
+
+    def mounted():
+        return ejs(_MOUNTED % json.dumps(DESC_SEL), group) is True
+
+    wait_for(mounted, TIMEOUT_SET, "描述编辑器组件挂载完成", group)
+    code = """(()=>{
+const v=(%s)(%s,'getView');
+if(!v)return JSON.stringify({ok:false,why:'no-component'});
+const view=v.getView();
+if(!view)return JSON.stringify({ok:false,why:'no-view'});
+const st=view.state;
+view.dispatch(st.tr.insertText(%s,0,st.doc.content.size));
+return JSON.stringify({ok:true});
+})()""" % (_VM, json.dumps(DESC_SEL), json.dumps(desc))
+    r = ejs_json(code, group)
+    if not isinstance(r, dict) or not r.get("ok"):
+        die("描述编辑器没找到", f"编辑器里现在是：{r}")
+
+    check = """(()=>{
+const v=(%s)(%s,'getContent');
+const d=(document.querySelector('.share-text__input .ProseMirror')||{}).innerText||'';
+let c='';try{c=v?v.getContent()||'':''}catch(e){c='err:'+e.message}
+return JSON.stringify({d:d.trim(),c:(c||'').trim()});
+})()""" % (_VM, json.dumps(DESC_READ_SEL))
+
+    def probe():
+        rr = ejs_json(check, group)
+        return (isinstance(rr, dict) and rr.get("d") == desc and rr.get("c") == desc)
+
+    wait_for(probe, TIMEOUT_SET, "描述写入并同步", group)
+    time.sleep(0.5)
+
+
+def upload_images(image_paths, group):
+    if not image_paths:
+        return [], []
+    log(f"[5/8] 上传 {len(image_paths)} 张图")
+
+    items = []
+    for path in image_paths:
+        if not os.path.isfile(path):
+            die(f"图片文件不存在：{path}")
+        try:
+            with open(path, "rb") as f:
+                data = f.read()
+        except OSError as e:
+            die(f"读图片失败：{path}：{e}")
+        ext = os.path.splitext(path)[1].lstrip(".").lower() or "png"
+        items.append({
+            "b64": __import__("base64").b64encode(data).decode(),
+            "name": os.path.basename(path),
+            "type": "image/png" if ext == "png" else "image/jpeg",
+        })
+    total_b64 = sum(len(it["b64"]) for it in items)
+    if total_b64 > B64_ARG_LIMIT:
+        die(f"图片 base64 共 {total_b64} 字符，超过 {B64_ARG_LIMIT} 上限",
+            "图片可能过大，或一次传的图太多。单张控制在几百 KB 内，或分批调用。")
+    if len(items) > IMG_MAX:
+        die(f"一次最多 {IMG_MAX} 张图，收到 {len(items)} 张")
+
+    payload = json.dumps(items, ensure_ascii=False)
+    code = ("(function(){ var ready=(%s)();"
+            "window.__fragoTietu.addImages(%s); return 'kicked'; })()"
+            % (_INJECTOR, payload))
+    if ejs(code, group) is None:
+        die("上传脚本没跑起来", "图片注入脚本执行失败，页面可能已失效。")
+
+    deadline = time.time() + 60 + 5 * len(items)
+    last = None
+    while time.time() < deadline:
+        time.sleep(1.0)
+        last = ejs_json("(()=>JSON.stringify(window.__fragoTietu&&window.__fragoTietu.result||null))()",
+                        group)
+        if isinstance(last, dict):
+            if last.get("state") == "error":
+                die("图片上传失败：" + str(last.get("error")),
+                    "上传素材库接口可能频控（稍后重试）或登录态已失效。")
+            if last.get("state") == "done":
+                got = last.get("innerList") or []
+                if len(got) != len(items):
+                    die(f"图片进了 {len(got)} 张，预期 {len(items)} 张",
+                        "改版会导致静默失败：上传成功但图不进 innerList。请人工打开编辑器确认。")
+                log(f"    {len(got)} 张图已进编辑器（file_id: "
+                    + ", ".join(str(x.get("file_id")) for x in got) + "）")
+                return got, last.get("uploaded") or []
+    die("图片上传超时", f"最后状态：{last}")
+
+    return [], []  # unreachable
+
+
+def read_state(group):
+    """读回标题/描述/图片数。标题读 getContent()——保存时页面读的就是这一个，
+    自检读它才等于自检了将要被提交的东西。currentPlainContent 只是它的缓存副本。"""
+    code = """(()=>{
+const vmOf=(%s);
+const t=vmOf(%s,'getContent');
+let title='';
+if(t){try{title=(t.getContent()||'').trim()}catch(e){}}
+const g=vmOf(%s,'getContent');
+let desc='';
+if(g){try{desc=(g.getContent()||'').trim()}catch(e){}}
+const vm=document.querySelector('.image-selector');
+return JSON.stringify({
+  title:title,
+  desc:desc,
+  images:vm&&vm.__vue__&&vm.__vue__.innerList?vm.__vue__.innerList.length:0
+});
+})()""" % (_VM, json.dumps(TITLE_SEL), json.dumps(DESC_READ_SEL))
+    r = ejs_json(code, group)
+    if not isinstance(r, dict):
+        return None
+    if r.get("desc") == "填写描述信息，让大家了解更多内容":
+        r["desc"] = ""
+    return r
+
+
+def precheck(sent, group):
+    """点保存前确认标题/描述/图片都到位。空的就报错——不点保存。"""
+    log("[6/8] 存前自检")
+    got = read_state(group)
+    if not got:
+        die("存前自检读不回状态", "不点保存，避免在草稿箱留下空内容。")
+    if got.get("title") != sent.get("title"):
+        die(f"存前自检不通过：标题应为「{sent.get('title')}」，编辑器里是「{got.get('title')}」",
+            "不点保存。")
+    if sent.get("desc") and not got.get("desc"):
+        die("存前自检不通过：描述没写进去", "不点保存。")
+    if sent.get("images") and got.get("images") != sent.get("images"):
+        die(f"存前自检不通过：图片应为 {sent.get('images')} 张，编辑器里 {got.get('images')} 张",
+            "不点保存。")
+    log(f"    编辑器里标题「{got.get('title')}」/ 描述 {len(got.get('desc'))} 字 / "
+        f"{got.get('images')} 张图")
+    return got
+
+
+def verify_stored(token, appmsgid, sent, group):
+    log("[8/8] 重开贴图草稿回读校验")
+    url = EDITOR_EDIT.format(appmsgid=appmsgid, token=token)
+
+    def open_and_read():
+        navigate(url, group)
+
+        def probe():
+            if ejs("(()=>!!window.__MP_Editor_JSAPI__)()", group) is not True:
+                return False
+            return ejs(_MOUNTED % json.dumps(TITLE_SEL), group) is True
+
+        wait_for(probe, TIMEOUT_EDITOR, "贴图草稿重新打开", group)
+        time.sleep(0.5)
+        return read_state(group)
+
+    # 页面加载完就定死了这一份数据，原地轮询它一万年也不会变。要么这一次就对，
+    # 要么重新导航再取一份。留两次重开的余地，兜住后台落库比回读慢半拍的情况。
+    got = open_and_read()
+    for _ in range(2):
+        if got and got.get("title") == sent.get("title"):
+            break
+        log("    回读到的还是旧标题，重开一次再看")
+        time.sleep(2)
+        got = open_and_read()
+
+    if not got:
+        WARNINGS.append("回读校验没读到状态，草稿可能已建成但内容存疑，请人工打开确认")
+        return {"title": "", "desc": "", "images": 0}
+    if got.get("title") != sent.get("title"):
+        die(f"回读校验不通过：标题应为「{sent.get('title')}」，草稿里是「{got.get('title')}」",
+            f"草稿已建成（ID {appmsgid}），请人工打开确认。")
+    if sent.get("desc") and sent.get("desc") not in (got.get("desc") or ""):
+        die(f"回读校验不通过：描述内容没保住，草稿里是「{got.get('desc')}」",
+            f"草稿已建成（ID {appmsgid}），请人工打开确认。")
+    if sent.get("images") and got.get("images") != sent.get("images"):
+        die(f"回读校验不通过：图片应为 {sent.get('images')} 张，草稿里 {got.get('images')} 张",
+            f"草稿已建成（ID {appmsgid}），请人工打开确认。")
+    log(f"    草稿里标题「{got.get('title')}」/ 描述 {len(got.get('desc'))} 字 / "
+        f"{got.get('images')} 张图")
+    return got

--- a/community-recipes/recipes/wechat_draft_create/recipe.md
+++ b/community-recipes/recipes/wechat_draft_create/recipe.md
@@ -1,0 +1,167 @@
+---
+name: wechat_draft_create
+type: atomic
+runtime: python
+version: "1.1"
+description: "把内容送进公众号草稿箱（文章/贴图两种类型）：走后台编辑器官方 JSAPI 与 Vue 组件接口，吃网页登录态，不需要 AppSecret 和 IP 白名单"
+use_cases:
+  - "接 markdown_to_wechat_html 的产出，一步把排好版的文章落成公众号草稿"
+  - "建贴图（image post, createType=8）草稿：标题 + 描述 + 最多 20 张图"
+  - "个人主体或未认证账号被回收发布接口权限时，绕开开放接口建草稿"
+  - "干跑模式把内容填进编辑器不保存，人肉眼确认排版后再决定要不要落"
+  - "拿草稿 ID 更新已有草稿，反复调整不产生新草稿"
+tags:
+  - wechat
+  - mp
+  - draft
+  - publishing
+  - browser
+output_targets:
+  - stdout
+inputs:
+  content_type:
+    type: string
+    required: false
+    description: "article（默认，图文）或 poster（贴图）。贴图=图+标题(≤20字)+描述(≤1000字)"
+  title:
+    type: string
+    required: true
+    description: "标题。文章上限 64 字，贴图上限 20 字，超长直接报错"
+  html_path:
+    type: string
+    required: false
+    description: "排好版的 HTML 文件路径（仅 article）。与 content 二选一，两个都不给直接报错"
+  content:
+    type: string
+    required: false
+    description: "直接给 HTML 全文（仅 article）"
+  cover:
+    type: string
+    required: false
+    description: "文章封面图文件路径（仅 article）。上传素材库后调官方桥设封面，建议 700KB 内"
+  description:
+    type: string
+    required: false
+    description: "贴图描述，公众号上限 1000 字"
+  images:
+    type: array
+    required: false
+    description: "贴图图片文件路径列表（也可给单路径字符串）。更新草稿时传图=替换旧图，不传图=保留旧图。单张建议几百 KB 内"
+  author:
+    type: string
+    required: false
+    description: "文章作者，公众号上限 8 字（仅 article）"
+  appmsgid:
+    type: string
+    required: false
+    description: "给了就更新这篇已有草稿，不给就新建"
+  browser_group:
+    type: string
+    required: false
+    description: "frago browser 的分组名，默认 wechat_draft"
+  verify:
+    type: boolean
+    required: false
+    description: "保存后是否回读校验，默认 true"
+  dry_run:
+    type: boolean
+    required: false
+    description: "只把内容填进编辑器不点保存，默认 false"
+outputs:
+  success:
+    type: boolean
+    description: "是否成功。任何一步没达成预期都为 false 且退出码非零"
+  appmsgid:
+    type: string
+    description: "草稿 ID。干跑时为空"
+  draft_url:
+    type: string
+    description: "可直接打开的草稿编辑地址"
+  title:
+    type: string
+    description: "标题"
+  description:
+    type: string
+    description: "回读到的贴图描述（仅 poster）"
+  images:
+    type: integer
+    description: "回读到的贴图图片数（仅 poster）"
+  uploaded_files:
+    type: array
+    description: "本次上传的素材 file_id 列表（仅 poster 且传了图）"
+  sent_chars:
+    type: integer
+    description: "送进编辑器的文章字符数（仅 article）"
+  stored_chars:
+    type: integer
+    description: "回读到的文章字符数（仅 article）"
+  sent_styles:
+    type: integer
+    description: "送进去的行内样式数（仅 article）"
+  stored_styles:
+    type: integer
+    description: "回读到的行内样式数（仅 article）"
+  tables:
+    type: integer
+    description: "回读到的文章表格数（仅 article）"
+  elapsed_sec:
+    type: number
+    description: "整段耗时"
+  warnings:
+    type: array
+    description: "回读校验对不上的项、以及其他非致命提示"
+---
+
+# wechat_draft_create
+
+把内容送进公众号草稿箱，支持**文章（图文）**与**贴图（image post）**两种内容类型。
+
+## 走的哪条路
+
+不走开放接口。公众号的开放接口要 AppSecret、要出口 IP 登记白名单，而且 2025 年 7 月起个人主体账号、企业主体未认证账号被回收了发布相关接口权限。
+
+走的是后台编辑器页面上的官方桥 `window.__MP_Editor_JSAPI__`——微信开给第三方插件用的接口，有正式文档（`developers.weixin.qq.com/doc/subscription/guide/product/mp_editor_jsapi.html`）。文章的正文用它设置，行内样式一个不掉。
+
+贴图（createType=8）没有正文，是「图 + 标题 + 描述」的轻量形态，走编辑器自己的 Vue 组件接口：
+- 标题/描述是 ProseMirror 富文本，写入必须走组件暴露的 ProseMirror `view.dispatch()` 事务 API——execCommand 只改 DOM 不同步内部状态、组件的 `setContent` 只改 Vue 数据不碰 view，保存时都会丢（见 `wechat-writing/mp-tietu-image-upload-path`）
+- 图片上传：上游 `POST /cgi-bin/filetransfer?action=upload_material` 上素材库（普通 multipart，同源带 cookie），下游把结果按 WebUploader 事件语义喂给 `.image-selector` 的 `uploadSelect → uploadComplete → uploadAllComplete`，组件自己补 seq/宽高/选中
+
+代价是吃网页登录态：浏览器里公众号后台必须是登录状态，登录态失效就跑不动。
+
+## 动作序列（两种类型共用骨架）
+
+1. 导航后台首页，从重定向后的地址里取 token（不写死，随会话变）
+2. 打开目标类型的编辑器页（article: type=10；poster: createType=8；更新都是 type=77&appmsgid）
+3. 等编辑器就绪（官方接口回报 isReady，poster 另等标题 ProseMirror）
+4. 填内容（article: 标题+正文；poster: 标题+描述+图片）
+5. 点保存前先读一次确认内容真进去了
+6. 点「保存为草稿」（五连事件：pointerdown/mousedown/pointerup/mouseup/click）
+7. 从跳转后的地址取草稿 ID，重开草稿回读校验
+
+## 已知的失败路径（别改成这些写法）
+
+- 合成 ClipboardEvent 粘贴富文本 → 被编辑器降级成纯文本，样式全丢
+- 直接给编辑器容器赋 innerHTML → 保存时被内部状态重新渲染覆盖
+- 去读 `.ProseMirror` 容器的 innerHTML 判断正文 → 那不是正文区，正文只能用 mp_editor_get_content 读
+- 朴素 `<li>文字</li>` 直接送，或 `<li>` 之间带换行/缩进 → 公众号编辑器会把 li 之间的空白解析成空列表项、
+  把无 section 包裹的 li 拆成「空 li + 文字 li」两段，项目符号落在空行上。
+  配方已自动处理：压缩 ul 内标签间空白 + 给朴素 li 包 `<section>`（带 li 的行内样式）。
+  排版配方（markdown_to_wechat_html）的标准输出两者都规避，不受影响
+- 贴图标题用 execCommand 或组件的 `setContent` 写入 → 只改 DOM/Vue 数据，保存读的是 ProseMirror view 状态，更新草稿时会丢，必须走 `getView().dispatch()` 事务
+- 贴图重开校验读太快 → 重开页标题先渲染旧值、服务器提交后翻新，要等标题等于预期值再校验
+
+## 用法
+
+```bash
+# 接排版配方的产出建文章草稿（可带封面）
+frago recipe run wechat_draft_create --params '{"title":"我的文章","html_path":"/path/to/article.html","cover":"/path/to/cover.png"}'
+
+# 建贴图草稿（图 + 标题 + 描述）
+frago recipe run wechat_draft_create --params '{"content_type":"poster","title":"贴图标题","description":"描述文字","images":["/path/a.png","/path/b.png"]}'
+
+# 更新已有贴图草稿（传图替换旧图，不传图保留旧图）
+frago recipe run wechat_draft_create --params '{"content_type":"poster","title":"新标题","description":"新描述","images":["/path/c.png"],"appmsgid":"200005074"}'
+
+# 干跑：填进编辑器不保存，人肉确认排版
+frago recipe run wechat_draft_create --params '{"content_type":"poster","title":"贴图标题","description":"描述","dry_run":true}'
+```

--- a/community-recipes/recipes/wechat_draft_create/recipe.py
+++ b/community-recipes/recipes/wechat_draft_create/recipe.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""wechat_draft_create — 把内容送进公众号草稿箱，支持文章（图文）与贴图两种类型。
+
+走的是后台编辑器页面上的官方桥 window.__MP_Editor_JSAPI__（微信开给第三方插件用、
+有正式文档），吃网页登录态，不碰 AppSecret、不碰 IP 白名单。
+
+- content_type=article（默认）：把排好版的 HTML 送进标准图文编辑器，行内样式一个不掉。
+- content_type=poster：送进贴图（createType=8）编辑器，支持标题/描述/多图。
+
+链路：取 token → 打开目标类型编辑器 → 等就绪 → 填内容 → 存前自检 → 点保存
+      → 取草稿 ID → 重开回读校验。
+
+每一步等的是条件成立而不是固定时长；任何一步没达成预期都退出码非零，绝不静默成功。
+"""
+
+import base64
+import json
+import re
+import subprocess
+import sys
+import time
+
+from common import (WARNINGS, click_save, die, get_token, log)
+
+from editors import article as article_driver
+from editors import poster as poster_driver
+
+
+def read_html_param(params):
+    """取 html_path/content，抽出根容器那一段送进编辑器。"""
+    html = params.get("content")
+    if not html:
+        path = params.get("html_path")
+        if not path:
+            die("html_path 与 content 至少给一个")
+        try:
+            with open(path, encoding="utf-8") as f:
+                html = f.read()
+        except OSError as e:
+            die(f"读不到 HTML 文件：{e}")
+    # 排版配方产出的是整页 HTML，这里只取根容器那一段送进编辑器。
+    m = re.search(r'<section[^>]*id="frago-wechat".*</section>', html, re.S)
+    if m:
+        html = m.group(0)
+    elif "<body" in html:
+        m2 = re.search(r"<body[^>]*>(.*)</body>", html, re.S)
+        if m2:
+            html = m2.group(1).strip()
+    if not html.strip():
+        die("要送进去的 HTML 是空的")
+    return normalize_lists(html)
+
+
+def normalize_images(params):
+    """images 参数可以是单路径字符串或列表。"""
+    imgs = params.get("images")
+    if not imgs:
+        return []
+    if isinstance(imgs, str):
+        return [imgs]
+    if isinstance(imgs, list):
+        out = []
+        for x in imgs:
+            if isinstance(x, str):
+                out.append(x)
+            elif isinstance(x, dict) and x.get("path"):
+                out.append(x["path"])
+            else:
+                die(f"images 项格式不对：{x!r}（应为路径字符串或 {{path}}）")
+        return out
+    die(f"images 参数格式不对：{type(imgs).__name__}")
+
+
+# 朴素 <li>纯文本</li> → <li><section style=…>纯文本</section></li>。
+# 公众号编辑器对没有 section 包裹的 li 会拆成「空 li + 文字 li」两段，项目符号落在空行上。
+# 两个坑都实测过：
+#   1) 没有 section 包裹的朴素 li 会被拆分；
+#   2) li 之间的换行/缩进空白会被解析成空列表项（canonical 排版输出 li 全在一行所以没事）。
+# 排版配方（markdown_to_wechat_html）的标准输出两者都规避，不受影响。
+_LI_RE = re.compile(
+    r"<li([^>]*)>((?:(?!</li>|</?section|<p[ >]|<div[ >]|<ul[ >]|<ol[ >]|<h[1-6][ >]|<table|<blockquote).)*?)</li>",
+    re.S)
+_UL_RE = re.compile(r"<ul[^>]*>[\s\S]*?</ul>", re.S)
+
+
+def _wrap_li(m):
+    li_attr = m.group(1)
+    sm = re.search(r'style="([^"]*)"', li_attr)
+    sec_style = sm.group(1) if sm else ""
+    sec_attr = (' style="%s"' % sec_style) if sec_style else ""
+    return "<li%s><section%s>%s</section></li>" % (li_attr, sec_attr, m.group(2))
+
+
+def normalize_lists(html):
+    def compact_ul(m):
+        inner = re.sub(r">\s+<", "><", m.group(0))
+        return inner
+    html = _UL_RE.sub(compact_ul, html)
+    return _LI_RE.sub(_wrap_li, html)
+
+
+def run_article(params, group, dry_run, do_verify, appmsgid_in):
+    drv = article_driver
+    title = (params.get("title") or "").strip()
+    if len(title) > drv.TITLE_MAX:
+        die(f"标题 {len(title)} 字，超过公众号上限 {drv.TITLE_MAX} 字")
+    author = (params.get("author") or "").strip()
+    if len(author) > drv.AUTHOR_MAX:
+        die(f"作者 {len(author)} 字，超过公众号上限 {drv.AUTHOR_MAX} 字")
+    cover = (params.get("cover") or "").strip()
+    html = read_html_param(params)
+    sent = {
+        "len": len(html),
+        "styles": len(re.findall(r"style=", html)),
+        "tables": len(re.findall(r"<table", html)),
+        "images": len(re.findall(r"<img", html)),
+        "cover": bool(cover),
+    }
+
+    token = get_token(group)
+    drv.open_editor(token, group, appmsgid_in)
+    drv.wait_editor_ready(group)
+    drv.set_title(title, author, group)
+    drv.set_content(html, group)
+    if cover:
+        drv.set_cover(cover, group)
+    in_editor = drv.precheck(sent["len"], group)
+
+    if dry_run:
+        log("[干跑] 内容已填进编辑器，不点保存")
+        return {
+            "success": True, "dry_run": True, "appmsgid": appmsgid_in or "",
+            "draft_url": drv.current_url(group), "title": title,
+            "sent_chars": sent["len"], "stored_chars": in_editor["len"],
+            "sent_styles": sent["styles"], "stored_styles": in_editor["styles"],
+            "tables": in_editor["tables"], "images": in_editor["images"],
+        }
+
+    appmsgid, _ = click_save(group)
+    stored = in_editor
+    if do_verify:
+        stored = drv.verify_stored(token, appmsgid, sent, group)
+
+    return {
+        "success": True, "dry_run": False, "appmsgid": appmsgid,
+        "draft_url": drv.EDITOR_EDIT.format(appmsgid=appmsgid, token=token),
+        "title": title, "cover": cover or "",
+        "sent_chars": sent["len"], "stored_chars": stored["len"],
+        "sent_styles": sent["styles"], "stored_styles": stored["styles"],
+        "tables": stored["tables"], "images": stored["images"],
+    }
+
+
+def run_poster(params, group, dry_run, do_verify, appmsgid_in):
+    drv = poster_driver
+    title = (params.get("title") or "").strip()
+    if not title:
+        die("title 必填")
+    if len(title) > drv.TITLE_MAX:
+        die(f"贴图标题 {len(title)} 字，超过上限 {drv.TITLE_MAX} 字")
+    desc = (params.get("description") or "").strip()
+    if len(desc) > drv.DESC_MAX:
+        die(f"贴图描述 {len(desc)} 字，超过上限 {drv.DESC_MAX} 字")
+    image_paths = normalize_images(params)
+    if not image_paths and not desc:
+        die("贴图至少给 description 或 images 之一，否则存下来是空内容")
+
+    sent = {
+        "title": title,
+        "desc": desc,
+        "images": len(image_paths),
+    }
+
+    token = get_token(group)
+    drv.open_editor(token, group, appmsgid_in)
+    drv.wait_editor_ready(group)
+    drv.set_title(title, group)
+    if desc:
+        drv.set_description(desc, group)
+    uploaded, uploaded_info = drv.upload_images(image_paths, group)
+    sent["images"] = len(uploaded)
+    in_editor = drv.precheck(sent, group)
+
+    if dry_run:
+        log("[干跑] 内容已填进贴图编辑器，不点保存")
+        return {
+            "success": True, "dry_run": True, "appmsgid": appmsgid_in or "",
+            "draft_url": drv.current_url(group), "title": title,
+            "description": in_editor["desc"], "images": in_editor["images"],
+            "uploaded_files": [x.get("file_id") for x in uploaded_info],
+        }
+
+    appmsgid, _ = click_save(group)
+    stored = in_editor
+    if do_verify:
+        stored = drv.verify_stored(token, appmsgid, sent, group)
+
+    return {
+        "success": True, "dry_run": False, "appmsgid": appmsgid,
+        "draft_url": drv.EDITOR_EDIT.format(appmsgid=appmsgid, token=token),
+        "title": title,
+        "description": stored["desc"], "images": stored["images"],
+        "uploaded_files": [x.get("file_id") for x in uploaded_info],
+    }
+
+
+def main():
+    started = time.time()
+    params = {}
+    if len(sys.argv) >= 2 and sys.argv[1].strip():
+        try:
+            params = json.loads(sys.argv[1])
+        except json.JSONDecodeError as e:
+            die(f"参数解析失败：{e}")
+
+    content_type = (params.get("content_type") or "article").strip().lower()
+    group = params.get("browser_group") or "wechat_draft"
+    dry_run = bool(params.get("dry_run"))
+    do_verify = params.get("verify", True)
+    appmsgid_in = params.get("appmsgid")
+
+    try:
+        if content_type == "poster":
+            result = run_poster(params, group, dry_run, do_verify, appmsgid_in)
+        elif content_type == "article":
+            result = run_article(params, group, dry_run, do_verify, appmsgid_in)
+        else:
+            die(f"content_type 不认识：{content_type}",
+                "支持 article（默认）与 poster（贴图）两种。")
+    except SystemExit:
+        raise
+
+    result["elapsed_sec"] = round(time.time() - started, 1)
+    result["warnings"] = WARNINGS
+    print(json.dumps(result, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except subprocess.TimeoutExpired as e:
+        die(f"浏览器命令超时：{e}")
+    except SystemExit:
+        raise
+    except Exception as e:  # noqa: BLE001
+        die(f"未预期的错误：{type(e).__name__}: {e}")


### PR DESCRIPTION
## New Recipe: wechat_draft_create

**Type:** atomic
**Runtime:** python
**Version:** 1.1

### Description

把内容送进公众号草稿箱（文章/贴图两种类型）：走后台编辑器官方 JSAPI 与 Vue 组件接口，吃网页登录态，不需要 AppSecret 和 IP 白名单

### Use Cases

- 接 markdown_to_wechat_html 的产出，一步把排好版的文章落成公众号草稿
- 建贴图（image post, createType=8）草稿：标题 + 描述 + 最多 20 张图
- 个人主体或未认证账号被回收发布接口权限时，绕开开放接口建草稿
- 干跑模式把内容填进编辑器不保存，人肉眼确认排版后再决定要不要落
- 拿草稿 ID 更新已有草稿，反复调整不产生新草稿

---

*Submitted via `frago recipe share`*
