### PR TITLE
fix(recipe): wechat_draft_create 贴图分批上传，多图不再被参数长度卡死

### DIFF
--- a/community-recipes/recipes/wechat_draft_create/editors/poster.py
+++ b/community-recipes/recipes/wechat_draft_create/editors/poster.py
@@ -27,8 +27,8 @@ TITLE_MAX = 20
 DESC_MAX = 1000
 IMG_MAX = 20
 
-# 图片 base64 全量塞进一次 exec-js 参数。ARG_MAX 上限 1MB（macOS），留余量给其他参数和 env。
-# 超过这个量直接报错，不静默截断。
+# 图片 base64 走 exec-js 参数传进页面，受 ARG_MAX 限制（macOS 1MB），留余量给其他参数和 env。
+# 这是**单次调用**的上限，不是总量上限：超过就分批喂，20 张的上限才是真的能用到 20 张。
 B64_ARG_LIMIT = 500_000
 
 # 上传完成（含 formatList 补宽高）需要的时间，单位秒。
@@ -81,22 +81,30 @@ _INJECTOR = r"""function() {
         return j;
       });
   }
-  function addImages(items) {
+  // 分三步：begin 清场 → addBatch 逐批追加（可调多次）→ finish 收尾。
+  // 拆开是因为图片 base64 一次塞不进 exec-js 的参数长度，只能分批喂；
+  // 而清空旧图和 uploadAllComplete 各自只能发生一次，不能跟着每批重复。
+  function begin() {
     var api = window.__fragoTietu;
     api.result = { state: 'running', uploaded: [], error: null };
+    api.seq = 0;
     var vm;
-    try { vm = vmOf(); } catch (e) { api.result = { state: 'error', error: '' + e }; return; }
+    try { vm = vmOf(); } catch (e) { api.result = { state: 'error', error: '' + e }; return 'error'; }
     // 替换语义：传了图就先清空现有图片，再传新的。更新草稿时旧图不会残留成重复。
     // 不带图更新（只改文字）不会走到这里，旧图保留。
     vm.innerList = [];
     vm.selected = null;
-    if (items.length > 20) {
-      api.result = { state: 'error', error: '超过 20 张上限' };
-      return;
-    }
+    return 'ok';
+  }
+  function addBatch(items) {
+    var api = window.__fragoTietu;
+    api.batch = { state: 'running', error: null, n: 0 };
+    var vm;
+    try { vm = vmOf(); } catch (e) { api.batch = { state: 'error', error: '' + e }; return 'error'; }
     var chain = Promise.resolve();
-    items.forEach(function (it, idx) {
+    items.forEach(function (it) {
       chain = chain.then(function () {
+        var idx = api.seq++;                     // 全局递增，tmpId 跨批不会撞
         var file = b64ToFile(it.b64, it.name || ('img' + idx + '.png'), it.type);
         return readSize(file).then(function (sz) {
           return uploadOne(vm, file).then(function (resp) {
@@ -106,11 +114,23 @@ _INJECTOR = r"""function() {
               width: sz.width, height: sz.height });
             vm.uploadComplete({ id: tmpId }, { content: resp.content, cdn_url: resp.cdn_url });
             api.result.uploaded.push({ file_id: resp.content, cdn_url: resp.cdn_url, w: sz.width, h: sz.height });
+            api.batch.n++;
           });
         });
       });
     });
-    chain.then(function () {
+    chain.then(function () { api.batch.state = 'done'; })
+         .catch(function (e) {
+           api.batch.state = 'error';
+           api.batch.error = '' + (e && e.message ? e.message : e);
+         });
+    return 'kicked';
+  }
+  function finish() {
+    var api = window.__fragoTietu;
+    var vm;
+    try { vm = vmOf(); } catch (e) { api.result = { state: 'error', error: '' + e }; return 'error'; }
+    Promise.resolve().then(function () {
       vm.uploadAllComplete();
       return new Promise(function (r) { setTimeout(r, 1500); });
     }).then(function () {
@@ -123,8 +143,10 @@ _INJECTOR = r"""function() {
       api.result.state = 'error';
       api.result.error = '' + (e && e.message ? e.message : e);
     });
+    return 'kicked';
   }
-  window.__fragoTietu = { addImages: addImages, result: null };
+  window.__fragoTietu = { begin: begin, addBatch: addBatch, finish: finish,
+                          result: null, batch: null, seq: 0 };
   return 'ready';
 }"""
 
@@ -306,41 +328,79 @@ def upload_images(image_paths, group):
             "name": os.path.basename(path),
             "type": "image/png" if ext == "png" else "image/jpeg",
         })
-    total_b64 = sum(len(it["b64"]) for it in items)
-    if total_b64 > B64_ARG_LIMIT:
-        die(f"图片 base64 共 {total_b64} 字符，超过 {B64_ARG_LIMIT} 上限",
-            "图片可能过大，或一次传的图太多。单张控制在几百 KB 内，或分批调用。")
     if len(items) > IMG_MAX:
         die(f"一次最多 {IMG_MAX} 张图，收到 {len(items)} 张")
 
-    payload = json.dumps(items, ensure_ascii=False)
+    batches = _split_batches(items)
+
     code = ("(function(){ var ready=(%s)();"
-            "window.__fragoTietu.addImages(%s); return 'kicked'; })()"
-            % (_INJECTOR, payload))
+            "return window.__fragoTietu.begin(); })()" % _INJECTOR)
     if ejs(code, group) is None:
         die("上传脚本没跑起来", "图片注入脚本执行失败，页面可能已失效。")
 
-    deadline = time.time() + 60 + 5 * len(items)
+    if len(batches) > 1:
+        log(f"    单次参数装不下，分 {len(batches)} 批喂")
+
+    for i, batch in enumerate(batches):
+        if i:
+            time.sleep(GAP_BETWEEN_UPLOADS)      # 批之间留口气，避开后台频控
+        payload = json.dumps(batch, ensure_ascii=False)
+        if ejs("(function(){ return window.__fragoTietu.addBatch(%s); })()" % payload,
+               group) is None:
+            die(f"第 {i + 1} 批图没喂进去", "页面可能已失效。")
+        _await_state("batch", 30 + 8 * len(batch), group,
+                     f"第 {i + 1}/{len(batches)} 批上传")
+        if len(batches) > 1:
+            log(f"    第 {i + 1}/{len(batches)} 批完成（{len(batch)} 张）")
+
+    if ejs("(function(){ return window.__fragoTietu.finish(); })()", group) is None:
+        die("上传收尾没跑起来", "页面可能已失效。")
+    last = _await_state("result", 60, group, "上传收尾")
+
+    got = last.get("innerList") or []
+    if len(got) != len(items):
+        die(f"图片进了 {len(got)} 张，预期 {len(items)} 张",
+            "改版会导致静默失败：上传成功但图不进 innerList。请人工打开编辑器确认。")
+    log(f"    {len(got)} 张图已进编辑器（file_id: "
+        + ", ".join(str(x.get("file_id")) for x in got) + "）")
+    return got, last.get("uploaded") or []
+
+
+def _split_batches(items):
+    """按 base64 体积切批，每批不超过单次 exec-js 参数上限。"""
+    batches, cur, cur_n = [], [], 0
+    for it in items:
+        n = len(it["b64"])
+        if n > B64_ARG_LIMIT:
+            die(f"单张图 {it['name']} base64 {n} 字符，一次就塞不进（上限 {B64_ARG_LIMIT}）",
+                "把这一张压小，几百 KB 以内。")
+        if cur and cur_n + n > B64_ARG_LIMIT:
+            batches.append(cur)
+            cur, cur_n = [], 0
+        cur.append(it)
+        cur_n += n
+    if cur:
+        batches.append(cur)
+    return batches
+
+
+def _await_state(key, timeout, group, what):
+    """轮询页面里 window.__fragoTietu[key].state，直到 done；error 或超时都直接 die。"""
+    deadline = time.time() + timeout
     last = None
     while time.time() < deadline:
         time.sleep(1.0)
-        last = ejs_json("(()=>JSON.stringify(window.__fragoTietu&&window.__fragoTietu.result||null))()",
-                        group)
+        last = ejs_json(
+            "(()=>JSON.stringify(window.__fragoTietu&&window.__fragoTietu.%s||null))()" % key,
+            group)
         if isinstance(last, dict):
             if last.get("state") == "error":
-                die("图片上传失败：" + str(last.get("error")),
+                die(f"{what}失败：" + str(last.get("error")),
                     "上传素材库接口可能频控（稍后重试）或登录态已失效。")
             if last.get("state") == "done":
-                got = last.get("innerList") or []
-                if len(got) != len(items):
-                    die(f"图片进了 {len(got)} 张，预期 {len(items)} 张",
-                        "改版会导致静默失败：上传成功但图不进 innerList。请人工打开编辑器确认。")
-                log(f"    {len(got)} 张图已进编辑器（file_id: "
-                    + ", ".join(str(x.get("file_id")) for x in got) + "）")
-                return got, last.get("uploaded") or []
-    die("图片上传超时", f"最后状态：{last}")
-
-    return [], []  # unreachable
+                return last
+    die(f"{what}超时", f"最后状态：{last}")
+    return {}  # unreachable
 
 
 def read_state(group):


### PR DESCRIPTION
## 问题

`wechat_draft_create` 建贴图草稿时，把所有图片的 base64 一次性塞进 exec-js 的参数里，
受 ARG_MAX 限制留了 50 万字符额度。实测 12 张 1800×2400 的成品图折算下来是 240 万字符，
直接报错退出。

也就是说配方声称的「最多 20 张图」是虚的——正常质量的图连 12 张都传不进去。
压缩也救不回来：降到 900×1200、32 色仍有 56 万字符，且画质已经不可用。

配方在社区库里，装了的人发多图都会撞这堵墙。

## 改法

把「一次喂全部」改成「分批喂」。页面侧的 `addImages` 拆成三段：

- `begin()` —— 清空旧图，重置累积状态，只发生一次
- `addBatch(items)` —— 追加上传这一批，可调多次
- `finish()` —— `uploadAllComplete` 收尾并汇总，只发生一次

拆开是因为清场和收尾各自只能发生一次，不能跟着每批重复。Python 侧按 base64 体积切批，
逐批调用并等这批落地再发下一批；图片序号跨批全局递增，避免 tmpId 相撞；批与批之间留
间隔避开后台频控（ret=200013）。

`B64_ARG_LIMIT` 的语义随之从「总量上限」变成「单次调用上限」，`IMG_MAX = 20` 的校验保留。

## 验证

12 张 1800×2400 的 PNG，切成 7 批，63 秒建成草稿；回读校验标题、995 字描述、12 张图全部就位。